### PR TITLE
feat: drips store

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9235,8 +9235,8 @@
       }
     },
     "node_modules/radicle-drips": {
-      "version": "0.2",
-      "resolved": "git+ssh://git@github.com/radicle-dev/drips-js-sdk.git#cfcb53c7149cea97285559b3e9e3d6138cd7e9d4",
+      "version": "v2",
+      "resolved": "git+ssh://git@github.com/radicle-dev/drips-js-sdk.git#8dd845367468207648acd771c2abb52a6daba35e",
       "peerDependencies": {
         "ethers": "^5.6.2"
       }
@@ -18656,8 +18656,8 @@
       }
     },
     "radicle-drips": {
-      "version": "git+ssh://git@github.com/radicle-dev/drips-js-sdk.git#cfcb53c7149cea97285559b3e9e3d6138cd7e9d4",
-      "from": "radicle-drips@https://github.com/radicle-dev/drips-js-sdk#feature/v2",
+      "version": "git+ssh://git@github.com/radicle-dev/drips-js-sdk.git#8dd845367468207648acd771c2abb52a6daba35e",
+      "from": "radicle-drips@github:radicle-dev/drips-js-sdk#feature/v2",
       "requires": {}
     },
     "randombytes": {

--- a/src/lib/components/connect-button/connect-button.svelte
+++ b/src/lib/components/connect-button/connect-button.svelte
@@ -2,6 +2,7 @@
   import Button from 'radicle-design-system/Button.svelte';
   import wallet from '$lib/stores/wallet';
   import ens from '$lib/stores/ens';
+  import drips from '$lib/stores/drips';
 
   async function connect() {
     await wallet.connect();
@@ -14,12 +15,14 @@
 
       // Connect all stores to wallet
       ens.connect(provider);
+      drips.connect(provider);
 
       // Lookup own name
       ens.lookup(address);
     } else {
       // Disconnect all stores from wallet
       ens.disconnect();
+      drips.disconnect();
     }
   }
 </script>

--- a/src/lib/stores/drips/drips.store.ts
+++ b/src/lib/stores/drips/drips.store.ts
@@ -1,0 +1,42 @@
+import type { Web3Provider } from '@ethersproject/providers';
+import { AddressAppClient, DripsSubgraphClient } from 'radicle-drips';
+import { writable } from 'svelte/store';
+
+interface State {
+  clients: {
+    addressApp: AddressAppClient;
+    subgraph: DripsSubgraphClient;
+  };
+}
+
+export default (() => {
+  const state = writable<State | undefined>();
+
+  /**
+   * Connect the store to a provider and initialize all Drips clients at `state.clients`.
+   * @param toProvider The provider to connect to.
+   */
+  async function connect(toProvider: Web3Provider): Promise<void> {
+    const { chainId } = toProvider.network;
+
+    state.set({
+      clients: {
+        subgraph: DripsSubgraphClient.create(chainId),
+        addressApp: await AddressAppClient.create(toProvider),
+      },
+    });
+  }
+
+  /**
+   * Disconnect the store from a previously-connected provider, and clear its state.
+   */
+  function disconnect(): void {
+    state.set(undefined);
+  }
+
+  return {
+    subscribe: state.subscribe,
+    connect,
+    disconnect,
+  };
+})();

--- a/src/lib/stores/drips/index.ts
+++ b/src/lib/stores/drips/index.ts
@@ -1,0 +1,1 @@
+export { default } from './drips.store';


### PR DESCRIPTION
Adds a new Drips store that creates instances of all Drips SDK clients and exposes them in its state.

In the future, we may add more drips-related information to the state of this store (such as info about the current cycle), which is why using a store pattern to share these client instances globally makes sense.