### PR TITLE
build: run svelte-kit sync in gh actions

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -8,4 +8,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
+      - name: Install Svelte Kit CLI
+        run: npm install @sveltejs/kit
+
+      - name: Svelte Kit Sync
+        run: npx svelte-kit sync
+
       - uses: wagoid/commitlint-github-action@v5

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -15,6 +15,9 @@ jobs:
       - name: Install E2E test browsers
         run: npx playwright install-deps
 
+      - name: Svelte Kit Sync
+        run: npx svelte-kit sync
+
       - name: Build app
         run: npm run build
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -12,5 +12,8 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      - name: Svelte Kit Sync
+        run: npx svelte-kit sync
+
       - name: Run tests
         run: npm run test:unit


### PR DESCRIPTION
Fix GH actions failing due to missing `./svelte-kit/tsconfig.json`