### PR TITLE
feat: account menu, settings page stub

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19342,7 +19342,7 @@
     },
     "radicle-drips": {
       "version": "git+ssh://git@github.com/radicle-dev/drips-js-sdk.git#9568dc8afc034e9f23f2e0239e73db3277618c16",
-      "from": "radicle-drips@github:radicle-dev/drips-js-sdk#v2",
+      "from": "radicle-drips@https://github.com/radicle-dev/drips-js-sdk#v2",
       "requires": {
         "moq.ts": "^9.0.2"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9592,7 +9592,7 @@
     },
     "node_modules/radicle-design-system": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/radicle-dev/radicle-design-system.git#7937ae66a20a6a00e0d8bbbf814e36227890a1fe",
+      "resolved": "git+ssh://git@github.com/radicle-dev/radicle-design-system.git#84707dd922a428862b8ea62d5580d8c3723788cf",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@types/lodash-es": "^4.17.6",
@@ -19329,7 +19329,7 @@
       "dev": true
     },
     "radicle-design-system": {
-      "version": "git+ssh://git@github.com/radicle-dev/radicle-design-system.git#7937ae66a20a6a00e0d8bbbf814e36227890a1fe",
+      "version": "git+ssh://git@github.com/radicle-dev/radicle-design-system.git#84707dd922a428862b8ea62d5580d8c3723788cf",
       "from": "radicle-design-system@https://github.com/radicle-dev/radicle-design-system",
       "requires": {
         "@types/lodash-es": "^4.17.6",
@@ -19342,7 +19342,7 @@
     },
     "radicle-drips": {
       "version": "git+ssh://git@github.com/radicle-dev/drips-js-sdk.git#9568dc8afc034e9f23f2e0239e73db3277618c16",
-      "from": "radicle-drips@https://github.com/radicle-dev/drips-js-sdk#v2",
+      "from": "radicle-drips@github:radicle-dev/drips-js-sdk#v2",
       "requires": {
         "moq.ts": "^9.0.2"
       }

--- a/src/lib/components/account-menu/account-menu.svelte
+++ b/src/lib/components/account-menu/account-menu.svelte
@@ -1,8 +1,43 @@
 <script>
   import wallet from '$lib/stores/wallet';
+  import SettingsIcon from 'radicle-design-system/icons/Settings.svelte';
   import CrossIcon from 'radicle-design-system/icons/CrossSmall.svelte';
   import Button from '../button/button.svelte';
+  import IdentityBadge from '../identity-badge/identity-badge.svelte';
+  import AccountMenuItem from './components/account-menu-item.svelte';
+  import { goto } from '$app/navigation';
+  import Divider from '../divider/divider.svelte';
 </script>
 
-Account menu placeholder
-<Button icon={CrossIcon} on:click={wallet.disconnect}>Disconnect wallet</Button>
+<div class="account-menu">
+  {#if $wallet.address}
+    <AccountMenuItem>
+      <svelte:fragment slot="left"
+        ><IdentityBadge
+          size="big"
+          address={$wallet.address}
+          showIdentity={false}
+        /></svelte:fragment
+      >
+      <svelte:fragment slot="title"
+        ><IdentityBadge address={$wallet.address} showAvatar={false} /></svelte:fragment
+      >
+      <svelte:fragment slot="right"
+        ><Button icon={CrossIcon} on:click={wallet.disconnect}>Disconnect</Button></svelte:fragment
+      >
+    </AccountMenuItem>
+    <Divider />
+    <AccountMenuItem icon={SettingsIcon} onClick={() => goto('/settings')}>
+      <svelte:fragment slot="title">Settings</svelte:fragment>
+    </AccountMenuItem>
+  {/if}
+</div>
+
+<style>
+  .account-menu {
+    display: flex;
+    gap: 1rem;
+    flex-direction: column;
+    padding: -0.25rem;
+  }
+</style>

--- a/src/lib/components/account-menu/account-menu.svelte
+++ b/src/lib/components/account-menu/account-menu.svelte
@@ -5,7 +5,6 @@
   import Button from '../button/button.svelte';
   import IdentityBadge from '../identity-badge/identity-badge.svelte';
   import AccountMenuItem from './components/account-menu-item.svelte';
-  import { goto } from '$app/navigation';
   import Divider from '../divider/divider.svelte';
 </script>
 
@@ -27,7 +26,7 @@
       >
     </AccountMenuItem>
     <Divider />
-    <AccountMenuItem icon={SettingsIcon} onClick={() => goto('/settings')}>
+    <AccountMenuItem icon={SettingsIcon} href="/settings">
       <svelte:fragment slot="title">Settings</svelte:fragment>
     </AccountMenuItem>
   {/if}

--- a/src/lib/components/account-menu/components/account-menu-item.svelte
+++ b/src/lib/components/account-menu/components/account-menu-item.svelte
@@ -1,0 +1,71 @@
+<script lang="ts">
+  import ChevronRight from 'radicle-design-system/icons/ChevronRight.svelte';
+  import type { SvelteComponent } from 'svelte';
+
+  export let disabled = false;
+  export let icon: typeof SvelteComponent | undefined = undefined;
+  export let onClick: (() => void) | undefined = undefined;
+</script>
+
+<div
+  class:disabled
+  class:clickable={onClick}
+  class="account-menu-item-wrapper"
+  on:click={() => !disabled && onClick && onClick()}
+  tabindex={onClick ? 0 : undefined}
+>
+  <slot name="left">
+    <div class="icon-wrapper">
+      {#if icon}<svelte:component this={icon} style="fill: var(--color-primary)" />{/if}
+    </div>
+  </slot>
+  <div class="description typo-text-bold">
+    <slot name="title" />
+  </div>
+  <slot name="right">
+    <ChevronRight />
+  </slot>
+</div>
+
+<style>
+  .account-menu-item-wrapper {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    padding: 0.25rem;
+    border-radius: 0.25rem;
+    transition: background-color 0.3s;
+  }
+
+  .account-menu-item-wrapper.clickable {
+    cursor: pointer;
+  }
+
+  .account-menu-item-wrapper.clickable:hover {
+    background-color: var(--color-foreground-level-1);
+  }
+
+  .account-menu-item-wrapper.clickable:focus {
+    background-color: var(--color-foreground-level-2);
+    outline: none;
+  }
+
+  .account-menu-item-wrapper.disabled {
+    opacity: 0.5;
+  }
+
+  .icon-wrapper {
+    height: 3rem;
+    width: 3rem;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background-color: var(--color-primary-level-1);
+    border-radius: 1.5rem;
+  }
+
+  .description {
+    flex: 1;
+    color: var(--color-foreground-level-6);
+  }
+</style>

--- a/src/lib/components/account-menu/components/account-menu-item.svelte
+++ b/src/lib/components/account-menu/components/account-menu-item.svelte
@@ -4,16 +4,10 @@
 
   export let disabled = false;
   export let icon: typeof SvelteComponent | undefined = undefined;
-  export let onClick: (() => void) | undefined = undefined;
+  export let href: string | undefined = undefined;
 </script>
 
-<div
-  class:disabled
-  class:clickable={onClick}
-  class="account-menu-item-wrapper"
-  on:click={() => !disabled && onClick && onClick()}
-  tabindex={onClick ? 0 : undefined}
->
+<a {href} class:disabled class:clickable={href} class="account-menu-item-wrapper">
   <slot name="left">
     <div class="icon-wrapper">
       {#if icon}<svelte:component this={icon} style="fill: var(--color-primary)" />{/if}
@@ -25,7 +19,7 @@
   <slot name="right">
     <ChevronRight />
   </slot>
-</div>
+</a>
 
 <style>
   .account-menu-item-wrapper {

--- a/src/lib/components/button/button.svelte
+++ b/src/lib/components/button/button.svelte
@@ -27,6 +27,7 @@
     border: 2px solid rgba(0, 0, 0, 0);
     user-select: none;
     transition: background-color 0.3s, color 0.3s, transform 0.1s, border 0.3s, opacity 0.3s;
+    white-space: nowrap;
   }
 
   button.with-icon {

--- a/src/lib/components/divider/divider.svelte
+++ b/src/lib/components/divider/divider.svelte
@@ -1,0 +1,9 @@
+<div class="divider" />
+
+<style>
+  .divider {
+    height: 0.1rem;
+    border-radius: 0.25rem;
+    background-color: var(--color-foreground-level-2);
+  }
+</style>

--- a/src/lib/components/flyout/flyout.svelte
+++ b/src/lib/components/flyout/flyout.svelte
@@ -63,7 +63,8 @@
   .content {
     position: absolute;
     left: 0;
-    width: 256px;
+    width: 24rem;
+    max-width: calc(100vw - 2rem);
   }
 
   .content.left {

--- a/src/lib/components/identity-badge/identity-badge.svelte
+++ b/src/lib/components/identity-badge/identity-badge.svelte
@@ -81,7 +81,6 @@
     color: var(--color-foreground-level-6);
     position: relative;
     text-align: left;
-    width: 100%;
   }
 
   .mono {

--- a/src/lib/stores/theme/theme.store.ts
+++ b/src/lib/stores/theme/theme.store.ts
@@ -1,0 +1,83 @@
+import { browser } from '$app/environment';
+import { get, writable } from 'svelte/store';
+import { z } from 'zod';
+
+export type Theme = 'light' | 'dark' | 'h4x0r';
+
+interface State {
+  selectedTheme: 'auto' | Theme;
+  currentTheme: Theme;
+}
+
+const storedThemeSchema = z.union([
+  z.literal('auto'),
+  z.literal('light'),
+  z.literal('dark'),
+  z.literal('h4x0r'),
+  z.null(),
+]);
+
+export default (() => {
+  const darkModeQuery = browser && window.matchMedia('(prefers-color-scheme: dark)');
+  const prefersDarkMode = darkModeQuery ? darkModeQuery.matches : false;
+  const preferredTheme = prefersDarkMode ? 'light' : 'dark';
+  const storedTheme = browser
+    ? storedThemeSchema.parse(localStorage.getItem('theme-preference'))
+    : null;
+
+  let initialSelectedTheme: 'auto' | Theme;
+  switch (storedTheme) {
+    case null: {
+      initialSelectedTheme = 'auto';
+      break;
+    }
+    default: {
+      initialSelectedTheme = storedTheme;
+    }
+  }
+
+  const state = writable<State>({
+    selectedTheme: initialSelectedTheme,
+    currentTheme: initialSelectedTheme === 'auto' ? preferredTheme : initialSelectedTheme,
+  });
+
+  if (browser) {
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
+      _updateTheme();
+    });
+    _updateTheme();
+  }
+
+  /**
+   * Set a new selected theme, which can be either an explicit theme value or 'auto' to
+   * follow the system value (dark or light) going forward.
+   * @param option The theme to select, or 'auto' to use the system theme.
+   */
+  function selectTheme(option: 'auto' | Theme) {
+    state.update((v) => ({
+      ...v,
+      selectedTheme: option,
+    }));
+
+    _updateTheme();
+
+    localStorage.setItem('theme-preference', option);
+  }
+
+  /** @private */
+  function _updateTheme() {
+    const { selectedTheme } = get(state);
+
+    if (selectedTheme === 'auto') {
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
+      state.update((v) => ({ ...v, currentTheme: prefersDark?.matches ? 'dark' : 'light' }));
+    } else {
+      state.update((v) => ({ ...v, currentTheme: selectedTheme }));
+    }
+  }
+
+  return {
+    subscribe: state.subscribe,
+    selectTheme,
+  };
+})();

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -20,17 +20,7 @@
   import { derived } from 'svelte/store';
   import tick from '$lib/stores/tick/tick.store';
   import ModalLayout from '$lib/components/modal-layout/modal-layout.svelte';
-
-  let prefersDarkMode = false;
-
-  onMount(() => {
-    const darkModeQuery = window.matchMedia('(prefers-color-scheme: dark)');
-    prefersDarkMode = darkModeQuery.matches;
-
-    darkModeQuery.addEventListener('change', (event) => {
-      prefersDarkMode = event.matches;
-    });
-  });
+  import themeStore from '$lib/stores/theme/theme.store';
 
   let walletConnected = false;
   let loaded = false;
@@ -135,7 +125,7 @@
 {/if}
 
 {#if loaded && !fatalError}
-  <div class="main" data-theme={prefersDarkMode ? 'dark' : 'light'}>
+  <div class="main" data-theme={$themeStore.currentTheme}>
     <ModalLayout />
     <div class="page">
       <slot />

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -1,0 +1,115 @@
+<script lang="ts">
+  import SegmentedControl from 'radicle-design-system/SegmentedControl.svelte';
+  import Divider from '$lib/components/divider/divider.svelte';
+  import Setting from './components/setting.svelte';
+  import themeStore, { type Theme } from '$lib/stores/theme/theme.store';
+
+  // Theme control
+  let selectedTheme: 'auto' | Theme = $themeStore.selectedTheme;
+  $: themeStore.selectTheme(selectedTheme);
+</script>
+
+<svelte:head>
+  <title>Drips — Settings</title>
+  <meta name="description" value="Radicle Drips Settings Page" />
+</svelte:head>
+
+<div class="settings">
+  <div class="header">
+    <h1>Settings</h1>
+    <p>All preferences below are stored locally on your device.</p>
+  </div>
+  <Divider />
+  <div class="section">
+    <h4 class="typo-all-caps">Appearance</h4>
+    <Setting title="Theme" subtitle="Adjust the appearance of UI elements across the app.">
+      <SegmentedControl
+        active={selectedTheme}
+        on:select={(value) => {
+          selectedTheme = value.detail;
+        }}
+        options={[
+          {
+            title: 'Auto',
+            value: 'auto',
+          },
+          {
+            title: 'Light',
+            value: 'light',
+          },
+          {
+            title: 'Dark',
+            value: 'dark',
+          },
+          {
+            title: 'h4x0r',
+            value: 'h4x0r',
+          },
+        ]}
+      />
+    </Setting>
+  </div>
+  <Divider />
+  <div class="section">
+    <h4 class="typo-all-caps">Get in touch</h4>
+    <Setting title="Join the discussion" subtitle="Join our Discord to chat with the team.">
+      <a class="typo-link" target="_blank" href="https://discord.gg/vhGXkazpNc"
+        >Open Discord Server</a
+      >
+    </Setting>
+  </div>
+  <Divider />
+  <div class="section">
+    <h4 class="typo-all-caps">Advanced</h4>
+    <Setting
+      title="Build on Drips"
+      subtitle="The Drips protocol is fully open-source and ready for you to build on."
+    >
+      <a class="typo-link" target="_blank" href="https://v2.docs.drips.network">Read the docs</a>
+    </Setting>
+  </div>
+  <Divider />
+  <div class="section">
+    <h4 class="typo-all-caps">Open Source Licenses</h4>
+    <Setting
+      title="Twemoji"
+      subtitle="Copyright 2020 Twitter, Inc and other contributors. Licensed under CC-BY 4.0."
+    />
+    <Setting
+      title="Inter"
+      subtitle="Font by Rasmus Andersson licensed under the SIL Open Font License 1.1."
+    />
+    <Setting
+      title="Source Code Pro"
+      subtitle="Font by Adobe Fonts distributed under the SIL Open Font License."
+    />
+  </div>
+</div>
+
+<style>
+  .settings {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+  }
+
+  .header {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  p {
+    color: var(--color-foreground-level-6);
+  }
+
+  h4 {
+    color: var(--color-foreground-level-5);
+  }
+
+  .section {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+</style>

--- a/src/routes/settings/components/setting.svelte
+++ b/src/routes/settings/components/setting.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+  export let title: string;
+  export let subtitle: string;
+</script>
+
+<div class="setting">
+  <div class="title">
+    <h3>{title}</h3>
+    <p>{subtitle}</p>
+  </div>
+  <slot />
+</div>
+
+<style>
+  .setting {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+  }
+
+  .title {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  p {
+    color: var(--color-foreground-level-6);
+  }
+
+  @media (max-width: 1024px) {
+    .setting {
+      flex-direction: column;
+      align-items: flex-start;
+    }
+  }
+</style>


### PR DESCRIPTION
Quick PR to add the account menu as seen in the designs + a basic settings page implementation which is missing most advanced settings still.

<img width="428" alt="Screenshot 2022-10-25 at 16 10 28" src="https://user-images.githubusercontent.com/1018218/197796641-30cbe976-c252-48d6-8be4-adb583a26517.png">
<img width="1728" alt="Screenshot 2022-10-25 at 17 56 46" src="https://user-images.githubusercontent.com/1018218/197823034-b85aed85-2d38-447a-85b4-13c4d88b8c0a.png">

Based on https://github.com/radicle-dev/drips-app-v2/pull/33 due to the new ability to set a `size` for `IdentityBadge` on this branch.

Resolves #34 and resolves #40 . We can add a network selector to the account menu once V2 is deployed to more than one testnet, and add the missing settings in follow-up PRs.