### PR TITLE
fix: section-skeleton does not update height when content changes

### DIFF
--- a/src/lib/components/section-skeleton/section-skeleton.svelte
+++ b/src/lib/components/section-skeleton/section-skeleton.svelte
@@ -3,7 +3,7 @@
   import { fade } from 'svelte/transition';
   import { tweened } from 'svelte/motion';
   import { cubicInOut } from 'svelte/easing';
-  import { tick } from 'svelte';
+  import { tick, onDestroy } from 'svelte';
   import Spinner from '../spinner/spinner.svelte';
 
   export let loaded = false;
@@ -33,6 +33,7 @@
     observer = new MutationObserver(() => updateContainerHeight());
     observer.observe(contentContainerElem, { childList: true });
   }
+  onDestroy(() => observer?.disconnect());
 
   $: {
     contentContainerElem;

--- a/src/lib/components/section-skeleton/section-skeleton.svelte
+++ b/src/lib/components/section-skeleton/section-skeleton.svelte
@@ -25,6 +25,20 @@
 
   let contentContainerElem: HTMLDivElement;
 
+  let observer: MutationObserver;
+  function observeContentChanges() {
+    observer?.disconnect();
+    if (!contentContainerElem) return;
+
+    observer = new MutationObserver(() => updateContainerHeight());
+    observer.observe(contentContainerElem, { childList: true });
+  }
+
+  $: {
+    contentContainerElem;
+    observeContentChanges();
+  }
+
   $: {
     if (loaded && !empty) {
       updateContainerHeight();
@@ -37,7 +51,7 @@
   async function updateContainerHeight(newHeight: number | void) {
     await tick();
 
-    newHeight = newHeight ?? contentContainerElem.getBoundingClientRect().height;
+    newHeight = newHeight ?? contentContainerElem.offsetHeight;
     containerHeight.set(newHeight);
   }
 </script>


### PR DESCRIPTION
The section-skeleton component currently sets its own height to the height of the content at the moment `loaded` is true and `empty` is false, but doesn't update its height if its slot content changes afterwards (for example after creating a new stream which is now displayed in the streams section. This PR makes the section skeleton update its own height whenever a DOM mutation of its slot is observed.