### PR TITLE
feat: simple connect page

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -187,6 +187,8 @@
   }
 
   .page {
+    position: relative;
+    min-height: 100vh;
     max-width: 64rem;
     width: 100vw;
     padding: 6rem 1rem 4rem 1rem;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,15 +1,40 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
   import wallet from '$lib/stores/wallet';
+  import Emoji from 'radicle-design-system/Emoji.svelte';
 
   $: {
     if ($wallet.connected) goto('/dashboard');
   }
 </script>
 
-<h1>Welcome page</h1>
-<p>
-  This page will urge the user to connect their wallet if they haven't yet, wait for all the stores
-  to be ready and then forward to the dashboard
-</p>
-<a href="/component-showcase" sveltekit:prefetch>Go to component showcase</a>
+<div class="welcome-page">
+  <Emoji size="huge" emoji="🌐" />
+  <div class="content">
+    <h1>Connect to Drips</h1>
+    <p>Connect your wallet to view your Dashboard.</p>
+  </div>
+</div>
+
+<style>
+  .welcome-page {
+    height: 100%;
+    padding: 30vh 0;
+    display: flex;
+    justify-content: center;
+    gap: 2rem;
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .content {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    flex-direction: column;
+  }
+
+  p {
+    color: var(--color-foreground-level-6);
+  }
+</style>


### PR DESCRIPTION
<img width="1728" alt="Screenshot 2022-10-28 at 16 57 22" src="https://user-images.githubusercontent.com/1018218/198662750-c7cb9c92-ffe4-4c6a-9b7d-f6bf0473cd1c.png">

Adds a simple initial connect page.

Resolves #24 