### PR TITLE
fix: quick promises break stepper height

### DIFF
--- a/src/lib/components/stepper/stepper.svelte
+++ b/src/lib/components/stepper/stepper.svelte
@@ -52,7 +52,7 @@
 
     if (stepElement instanceof HTMLDivElement) {
       observedElement = stepElement;
-      mutationObserver.observe(stepElement, { childList: true, attributes: true, subtree: true });
+      mutationObserver.observe(stepElement, { childList: true, subtree: true });
       updateContainerHeight();
     }
   }

--- a/src/lib/components/stepper/stepper.svelte
+++ b/src/lib/components/stepper/stepper.svelte
@@ -63,7 +63,7 @@
 
     if (!observedElement) return;
 
-    const stepHeight = stepElement.clientHeight;
+    const stepHeight = observedElement.clientHeight;
 
     containerHeight.set(stepHeight, {
       duration: firstHeightUpdate || disableTransition ? 0 : 300,


### PR DESCRIPTION
Resolves #51 

We were checking the height of `stepElement`, which is not always reliably equal to the current step due to an apparent bug (?) in Svelte with `bind:this` on transitioned elements. Checking the height of `observedElement` instead appears to fix the problem.