### PR TITLE
fix: negative outbound balance estimation in some situations

### DIFF
--- a/src/lib/stores/streams/methods/build-asset-configs.ts
+++ b/src/lib/stores/streams/methods/build-asset-configs.ts
@@ -115,8 +115,6 @@ export default function buildAssetConfigs(
           runsOutOfFunds = undefined;
         } else if (dripsSetEvent.maxEnd === 0n) {
           runsOutOfFunds = undefined;
-        } else if (dripsSetEvent.maxEnd === dripsSetEvent.blockTimestamp) {
-          runsOutOfFunds = undefined;
         } else {
           runsOutOfFunds = new Date(Number(dripsSetEvent.maxEnd) * 1000);
         }


### PR DESCRIPTION
There was a bug if an asset config was updated while already out of funds, resulting in the UI estimating a negative outbound balance for the given asset. This fixes that.