### PR TITLE
feat: profile view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9458,7 +9458,7 @@
     },
     "node_modules/radicle-drips": {
       "version": "2.0.0",
-      "resolved": "git+ssh://git@github.com/radicle-dev/drips-js-sdk.git#39003703016b02901cc8d5ac9f84098f3ad7c833",
+      "resolved": "git+ssh://git@github.com/radicle-dev/drips-js-sdk.git#8272f0c19bc1b31db5cba3d399b6555d12e05e40",
       "peerDependencies": {
         "ethers": "^5.6.2"
       }
@@ -18871,7 +18871,7 @@
       }
     },
     "radicle-drips": {
-      "version": "git+ssh://git@github.com/radicle-dev/drips-js-sdk.git#39003703016b02901cc8d5ac9f84098f3ad7c833",
+      "version": "git+ssh://git@github.com/radicle-dev/drips-js-sdk.git#8272f0c19bc1b31db5cba3d399b6555d12e05e40",
       "from": "radicle-drips@https://github.com/radicle-dev/drips-js-sdk#v2",
       "requires": {}
     },

--- a/src/e2e-tests/helpers/change-address.ts
+++ b/src/e2e-tests/helpers/change-address.ts
@@ -1,0 +1,6 @@
+import type { Page } from 'playwright';
+
+export default (page: Page, newAddress: string) =>
+  page.addInitScript(`
+    window.playwrightAddress = '${newAddress}';
+  `);

--- a/src/e2e-tests/helpers/configure-app-for-test.ts
+++ b/src/e2e-tests/helpers/configure-app-for-test.ts
@@ -1,0 +1,21 @@
+import type { Page } from 'playwright';
+
+export default (page: Page) =>
+  page.addInitScript(`
+    window.isPlaywrightTest = true;
+    window.playwrightAddress = '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266';
+
+    localStorage.setItem('custom-tokens', JSON.stringify([
+      {
+        "source": "custom",
+        "banned": false,
+        "info": {
+          "chainId": 5,
+          "address": "0x9A676e781A523b5d0C0e43731313A708CB607508",
+          "name": "Testcoin",
+          "decimals": 18,
+          "symbol": "TEST"
+        }
+      }
+    ]));
+`);

--- a/src/lib/components/account-menu/account-menu.svelte
+++ b/src/lib/components/account-menu/account-menu.svelte
@@ -1,11 +1,15 @@
 <script>
   import wallet from '$lib/stores/wallet';
   import SettingsIcon from 'radicle-design-system/icons/Settings.svelte';
+  import ServerIcon from 'radicle-design-system/icons/Server.svelte';
+  import UserIcon from 'radicle-design-system/icons/User.svelte';
+
   import CrossIcon from 'radicle-design-system/icons/CrossSmall.svelte';
   import Button from '../button/button.svelte';
   import IdentityBadge from '../identity-badge/identity-badge.svelte';
   import AccountMenuItem from './components/account-menu-item.svelte';
   import Divider from '../divider/divider.svelte';
+  import ens from '$lib/stores/ens';
 </script>
 
 <div class="account-menu">
@@ -25,7 +29,16 @@
         ><Button icon={CrossIcon} on:click={wallet.disconnect}>Disconnect</Button></svelte:fragment
       >
     </AccountMenuItem>
-    <Divider />
+    <Divider sideMargin={0.5} />
+    <AccountMenuItem icon={ServerIcon} href="/app/dashboard">
+      <svelte:fragment slot="title">Dashboard</svelte:fragment>
+    </AccountMenuItem>
+    <AccountMenuItem
+      icon={UserIcon}
+      href={`/app/${$ens[$wallet.address]?.name ?? $wallet.address}`}
+    >
+      <svelte:fragment slot="title">Profile</svelte:fragment>
+    </AccountMenuItem>
     <AccountMenuItem icon={SettingsIcon} href="/app/settings">
       <svelte:fragment slot="title">Settings</svelte:fragment>
     </AccountMenuItem>
@@ -35,8 +48,8 @@
 <style>
   .account-menu {
     display: flex;
-    gap: 1rem;
+    gap: 0.25rem;
     flex-direction: column;
-    padding: -0.25rem;
+    padding: -0.5rem;
   }
 </style>

--- a/src/lib/components/account-menu/components/account-menu-item.svelte
+++ b/src/lib/components/account-menu/components/account-menu-item.svelte
@@ -26,8 +26,8 @@
     display: flex;
     gap: 0.5rem;
     align-items: center;
-    padding: 0.25rem;
-    border-radius: 0.25rem;
+    padding: 0.5rem;
+    border-radius: 4rem;
     transition: background-color 0.3s;
   }
 

--- a/src/lib/components/avatar/avatar.svelte
+++ b/src/lib/components/avatar/avatar.svelte
@@ -29,6 +29,7 @@
     height: 100%;
     width: 100%;
     border-radius: calc(100% / 2);
+    object-fit: cover;
   }
 
   .placeholder {

--- a/src/lib/components/copyable/copyable.svelte
+++ b/src/lib/components/copyable/copyable.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+  import CopyIcon from 'radicle-design-system/icons/CopySmall.svelte';
+  import SuccessIcon from 'radicle-design-system/icons/CheckCircle.svelte';
+
+  export let value: string;
+
+  let success = false;
+  let visible = false;
+
+  async function copyClipboard(text: string) {
+    await navigator.clipboard.writeText(text);
+    success = true;
+    setTimeout(() => (success = false), 1000);
+  }
+</script>
+
+<div
+  class="copyable"
+  on:click={() => copyClipboard(value)}
+  on:mouseenter={() => (visible = true)}
+  on:mouseleave={() => (visible = false)}
+>
+  <slot />
+  <div class="copy-icon" class:visible={visible || success}>
+    {#if success}
+      <SuccessIcon style="fill: var(--color-positive)" />
+    {:else}<CopyIcon />{/if}
+  </div>
+</div>
+
+<style>
+  .copyable {
+    gap: 0.25rem;
+    display: flex;
+    cursor: pointer;
+  }
+
+  .copy-icon {
+    transform: translateX(-24px);
+    opacity: 0;
+    width: 0px;
+    transition: transform 0.3s, opacity 0.3s, width 0.3s;
+  }
+
+  .copy-icon.visible {
+    width: 24px;
+    opacity: 1;
+    transform: translateX(0);
+  }
+</style>

--- a/src/lib/components/divider/divider.svelte
+++ b/src/lib/components/divider/divider.svelte
@@ -1,4 +1,8 @@
-<div class="divider" />
+<script lang="ts">
+  export let sideMargin = 0;
+</script>
+
+<div class="divider" style={`margin: 0.25rem ${sideMargin}rem`} />
 
 <style>
   .divider {

--- a/src/lib/components/header/header.svelte
+++ b/src/lib/components/header/header.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import scroll from '$lib/stores/scroll';
+  import wallet from '$lib/stores/wallet';
   import ConnectButton from '../connect-button/connect-button.svelte';
   import DripsLogo from '././drips-logo.svelte';
 
@@ -7,7 +8,7 @@
 </script>
 
 <header class:elevated>
-  <a sveltekit:prefetch href="/">
+  <a sveltekit:prefetch href={$wallet.connected ? '/app/dashboard' : '/'}>
     <DripsLogo />
   </a>
   <div class="wallet">

--- a/src/lib/components/identity-badge/identity-badge.svelte
+++ b/src/lib/components/identity-badge/identity-badge.svelte
@@ -5,11 +5,14 @@
   import { createIcon } from 'radicle-design-system/lib/blockies';
   import Avatar from '$lib/components/avatar/avatar.svelte';
   import { browser } from '$app/environment';
+  import wallet from '$lib/stores/wallet';
+  import formatAddress from '$lib/utils/format-address';
 
   export let address: string;
   export let showIdentity = true;
   export let showAvatar = true;
-  export let size: 'normal' | 'big' | 'huge' = 'normal';
+  export let disableLink = false;
+  export let size: 'normal' | 'big' | 'huge' | 'gigantic' = 'normal';
 
   export let avatarImgElem: HTMLImageElement | undefined = undefined;
 
@@ -25,9 +28,11 @@
       }).toDataURL()) ||
     undefined;
 
-  function formatAddress(address: string) {
-    const unpadded = address.replace('0x', '');
-    return `${unpadded.substring(0, 4)}—${unpadded.slice(-4)}`;
+  function getLink() {
+    if (disableLink) return undefined;
+    if (address === $wallet.address) return '/app/dashboard';
+
+    return `/app/${ens?.name ?? address}`;
   }
 
   $: toDisplay = ens?.name ?? formatAddress(address);
@@ -36,6 +41,7 @@
     normal: 24,
     big: 48,
     huge: 64,
+    gigantic: 128,
   };
   $: currentSize = sizes[size];
 
@@ -43,11 +49,12 @@
     normal: 'typo-text-bold',
     big: 'typo-header-4',
     huge: 'typo-header-3',
+    gigantic: 'typo-header-1',
   };
   $: currentFontClass = fontClasses[size];
 </script>
 
-<div class="identity-badge" style:height={showAvatar ? `${currentSize}px` : ''}>
+<a href={getLink()} class="identity-badge" style:height={showAvatar ? `${currentSize}px` : ''}>
   {#if showAvatar}
     <Avatar
       size={currentSize}
@@ -61,8 +68,9 @@
       <p
         transition:fade|local={{ duration: 300 }}
         class:mono={!ens?.name}
+        class:foreground={size === 'gigantic'}
         class={`${currentFontClass} identity`}
-        style:left={showAvatar ? '2rem' : '0rem'}
+        style:left={showAvatar ? `${currentSize + currentSize / 3}px` : '0'}
       >
         {toDisplay}
       </p>
@@ -71,7 +79,7 @@
       {toDisplay}
     </p>
   {/if}
-</div>
+</a>
 
 <style>
   .identity-badge {
@@ -86,6 +94,10 @@
   .mono {
     font-family: var(--typeface-mono-bold);
     white-space: nowrap;
+  }
+
+  .foreground {
+    color: var(--color-foreground);
   }
 
   .identity {

--- a/src/lib/components/large-empty-state/large-empty-state.svelte
+++ b/src/lib/components/large-empty-state/large-empty-state.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+  import Emoji from 'radicle-design-system/Emoji.svelte';
+
+  export let emoji: string;
+  export let headline: string;
+  export let description: string;
+</script>
+
+<div class="large-empty-state">
+  <Emoji size="huge" {emoji} />
+  <div class="content">
+    <h1>{headline}</h1>
+    <p>{description}</p>
+    <p />
+  </div>
+</div>
+
+<style>
+  .large-empty-state {
+    height: 100%;
+    padding: 30vh 0;
+    display: flex;
+    justify-content: center;
+    gap: 2rem;
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .content {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    flex-direction: column;
+  }
+
+  p {
+    color: var(--color-foreground-level-6);
+  }
+</style>

--- a/src/lib/components/list-select/list-select.svelte
+++ b/src/lib/components/list-select/list-select.svelte
@@ -200,6 +200,7 @@
     gap: 0.5rem;
     align-items: center;
     color: var(--color-foreground-level-5);
+    text-align: center;
   }
 
   .list {

--- a/src/lib/components/section-skeleton/section-skeleton.svelte
+++ b/src/lib/components/section-skeleton/section-skeleton.svelte
@@ -7,8 +7,9 @@
   import Spinner from '../spinner/spinner.svelte';
 
   export let loaded = false;
-  export let empty = true;
+  export let empty = false;
   export let error = false;
+  export let placeholderOutline = true;
 
   export let emptyStateEmoji = '👻';
   export let emptyStateHeadline: string | undefined = 'Nothing to see here';
@@ -25,13 +26,13 @@
 
   let contentContainerElem: HTMLDivElement;
 
-  let observer: MutationObserver;
+  let observer: ResizeObserver;
   function observeContentChanges() {
     observer?.disconnect();
     if (!contentContainerElem) return;
 
-    observer = new MutationObserver(() => updateContainerHeight());
-    observer.observe(contentContainerElem, { childList: true });
+    observer = new ResizeObserver(() => updateContainerHeight());
+    observer.observe(contentContainerElem);
   }
   onDestroy(() => observer?.disconnect());
 
@@ -59,12 +60,35 @@
 
 <div class="section-skeleton" style:height={`${$containerHeight}px`}>
   {#if loaded}
-    {#if empty}
+    {#if error}
       <div
         in:fade={{ duration: 250 }}
         class="placeholder-container"
         style:height={`${$containerHeight}px`}
         style:position={placeholderContainerPosition}
+        style:border={placeholderOutline ? '2px solid var(--color-foreground-level-1)' : ''}
+      >
+        <div class="empty-state">
+          <Emoji emoji="⚠️" size="large" />
+          <div class="text-group">
+            <p class="typo-text-small-bold">Oops, something went wrong.</p>
+            <p class="typo-text-small">
+              Sorry, we weren't able to load this. There may be more information in the developer
+              console.
+            </p>
+            <a class="typo-link typo-text-small" href="https://discord.gg/vhGXkazpNc"
+              >Ask for help</a
+            >
+          </div>
+        </div>
+      </div>
+    {:else if empty}
+      <div
+        in:fade={{ duration: 250 }}
+        class="placeholder-container"
+        style:height={`${$containerHeight}px`}
+        style:position={placeholderContainerPosition}
+        style:border={placeholderOutline ? '2px solid var(--color-foreground-level-1)' : ''}
       >
         <div class="empty-state">
           <Emoji emoji={emptyStateEmoji} size="large" />
@@ -72,18 +96,6 @@
             {#if emptyStateHeadline}<p class="typo-text-small-bold">{emptyStateHeadline}</p>{/if}
             {#if emptyStateText}<p class="typo-text-small">{emptyStateText}</p>{/if}
           </div>
-        </div>
-      </div>
-    {:else if error}
-      <div class="empty-state">
-        <Emoji emoji="⚠️" size="large" />
-        <div class="text-group">
-          <p class="typo-text-small-bold">Oops, something went wrong.</p>
-          <p class="typo-text-small">
-            Sorry, we weren't able to load this. There may be more information in the developer
-            console.
-          </p>
-          <a class="typo-text-small" href="wikipedia.com">Ask for help</a>
         </div>
       </div>
     {:else}
@@ -97,6 +109,7 @@
       style:position={placeholderContainerPosition}
       class="placeholder-container"
       style:height={`${$containerHeight}px`}
+      style:border={placeholderOutline ? '2px solid var(--color-foreground-level-1)' : ''}
     >
       <Spinner />
     </div>
@@ -110,7 +123,6 @@
 
   .placeholder-container {
     width: 100%;
-    border: 2px solid var(--color-foreground-level-1);
     border-radius: 0.5rem;
     display: flex;
     justify-content: center;

--- a/src/lib/components/social-link/social-link.svelte
+++ b/src/lib/components/social-link/social-link.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+  import Twitter from 'radicle-design-system/icons/Twitter.svelte';
+  import Web from 'radicle-design-system/icons/Globe.svelte';
+  import Ethereum from 'radicle-design-system/icons/Ethereum.svelte';
+  import Github from 'radicle-design-system/icons/Github.svelte';
+  import type { SvelteComponent } from 'svelte';
+  import Copyable from '../copyable/copyable.svelte';
+  import formatAddress from '$lib/utils/format-address';
+
+  type SocialNetwork = 'com.twitter' | 'com.github' | 'url' | 'ethereum';
+
+  export let network: SocialNetwork;
+  export let value: string;
+
+  const icons: { [key in SocialNetwork]: typeof SvelteComponent } = {
+    ethereum: Ethereum,
+    'com.twitter': Twitter,
+    'com.github': Github,
+    url: Web,
+  };
+
+  $: icon = icons[network];
+
+  // Undefined = No link. Empty string = link without prefix.
+  const prefixes: { [key in SocialNetwork]: string | undefined } = {
+    ethereum: undefined,
+    'com.twitter': 'https://twitter.com/',
+    'com.github': 'https://github.com/',
+    url: '',
+  };
+
+  $: prefix = prefixes[network];
+  $: url = `${prefix}${value}`;
+</script>
+
+<div class="social-link">
+  <svelte:component this={icon} />
+  {#if prefix !== undefined}
+    <a target="_blank" class="typo-text-bold" href={url}>{value}</a>
+  {:else if network === 'ethereum'}
+    <p class="typo-text-bold"><Copyable {value}>{formatAddress(value)}</Copyable></p>
+  {/if}
+</div>
+
+<style>
+  .social-link {
+    display: flex;
+    gap: 0.25rem;
+  }
+
+  a,
+  p {
+    color: var(--color-foreground-level-6);
+  }
+
+  a:hover {
+    text-decoration: underline;
+  }
+</style>

--- a/src/lib/stores/balances/balances.store.ts
+++ b/src/lib/stores/balances/balances.store.ts
@@ -33,6 +33,8 @@ export default (() => {
   let tickRegistration: number | undefined;
   const state = writable<State>(INITIAL_STATE);
 
+  if (!tickRegistration) tickRegistration = tickStore.register(_updateAllBalances);
+
   /**
    * Connect the store to a given AddressDriverClient and fetch balances.
    */
@@ -41,8 +43,6 @@ export default (() => {
     dripsHubClient = await getDripsHubClient();
 
     userId = (await addressDriverClient.getUserId()).toString();
-
-    if (!tickRegistration) tickRegistration = tickStore.register(_updateAllBalances);
 
     await updateBalances();
   }

--- a/src/lib/stores/wallet/__test__/wallet.store.ts
+++ b/src/lib/stores/wallet/__test__/wallet.store.ts
@@ -25,7 +25,7 @@ export default (() => {
     connected: true,
     address: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
     provider,
-    signer,
+    signer: signer as unknown as ethers.providers.JsonRpcSigner,
     network: NETWORK,
   });
 

--- a/src/lib/stores/wallet/wallet.store.ts
+++ b/src/lib/stores/wallet/wallet.store.ts
@@ -13,7 +13,7 @@ import isTest from '$lib/utils/is-test';
 const { SUPPORTED_CHAINS } = Utils.Network;
 const DEFAULT_NETWORK: Network = {
   chainId: 5,
-  name: 'Görli',
+  name: 'goerli',
 };
 
 const INFURA_ID = 'aadcb5b20a6e4cc09edfdd664ed6334c';
@@ -31,7 +31,7 @@ export interface ConnectedWalletStoreState {
   connected: true;
   address: string;
   provider: ethers.providers.Web3Provider | ethers.providers.JsonRpcProvider;
-  signer: ethers.Signer;
+  signer: ethers.providers.JsonRpcSigner;
   network: Network;
 }
 
@@ -51,13 +51,15 @@ const windowProvider =
 const selectedNetwork =
   windowProvider && new ethers.providers.Web3Provider(window.ethereum).network;
 
+const initNetwork =
+  selectedNetwork && SUPPORTED_CHAINS.includes(selectedNetwork.chainId)
+    ? selectedNetwork
+    : DEFAULT_NETWORK;
+
 const INITIAL_STATE: DisconnectedWalletStoreState = {
   connected: false,
-  network:
-    selectedNetwork && SUPPORTED_CHAINS.includes(selectedNetwork.chainId)
-      ? selectedNetwork
-      : DEFAULT_NETWORK,
-  provider: new ethers.providers.InfuraProvider(),
+  network: initNetwork,
+  provider: new ethers.providers.InfuraProvider(initNetwork),
 };
 
 const walletStore = () => {

--- a/src/lib/utils/build-url.ts
+++ b/src/lib/utils/build-url.ts
@@ -1,0 +1,19 @@
+/**
+ * Genereate a URL path string from a path and object of parameters.
+ * @param path The URL path.
+ * @param params Query params to add to the URL.
+ * @returns A full URL path string including the supplied query parameters.
+ */
+export default function buildUrl(path: string, params: Record<string, string>) {
+  const query = { ...params };
+  let interpolatedPath = path;
+  for (const [param, value] of Object.entries(params)) {
+    const replaced = interpolatedPath.replace(`[${param}]`, value);
+    if (replaced !== interpolatedPath) {
+      interpolatedPath = replaced;
+      delete query[param];
+    }
+  }
+  const search = new URLSearchParams(query).toString();
+  return `${interpolatedPath}${search ? `?${search}` : ''}`;
+}

--- a/src/lib/utils/format-address.ts
+++ b/src/lib/utils/format-address.ts
@@ -1,0 +1,10 @@
+/**
+ * Formats an Ethereum address to a human-friendly format showing the first
+ * and last four characters.
+ * @param address The address to format.
+ * @returns The formatted address.
+ */
+export default function formatAddress(address: string) {
+  const unpadded = address.replace('0x', '');
+  return `${unpadded.substring(0, 4)}—${unpadded.slice(-4)}`;
+}

--- a/src/lib/utils/get-drips-clients.ts
+++ b/src/lib/utils/get-drips-clients.ts
@@ -26,10 +26,13 @@ export function getSubgraphClient() {
  * @returns An initialized Address Driver client.
  */
 export function getAddressDriverClient() {
-  const { provider, connected } = get(wallet);
-  assert(connected, 'Wallet must be connected to create an AddressDriverClient');
+  const { provider, connected, signer } = get(wallet);
 
-  return AddressDriverClient.create(provider, getNetworkConfig().CONTRACT_ADDRESS_DRIVER);
+  const addressDriverAddress = getNetworkConfig().CONTRACT_ADDRESS_DRIVER;
+
+  return connected
+    ? AddressDriverClient.create(signer, addressDriverAddress)
+    : AddressDriverClient.createReadonly(provider, addressDriverAddress);
 }
 
 /**
@@ -37,10 +40,13 @@ export function getAddressDriverClient() {
  * @returns An initialized Drips Hub client.
  */
 export function getDripsHubClient() {
-  const { provider, connected } = get(wallet);
-  assert(connected, 'Wallet must be connected to create a DripsHubClient');
+  const { provider, connected, signer } = get(wallet);
 
-  return DripsHubClient.create(provider, getNetworkConfig().CONTRACT_DRIPS_HUB);
+  const dripsHubAddress = getNetworkConfig().CONTRACT_DRIPS_HUB;
+
+  return connected
+    ? DripsHubClient.create(signer, dripsHubAddress)
+    : DripsHubClient.createReadonly(provider, dripsHubAddress);
 }
 
 /**

--- a/src/lib/utils/guard-connected.ts
+++ b/src/lib/utils/guard-connected.ts
@@ -1,0 +1,24 @@
+import { goto } from '$app/navigation';
+import { page } from '$app/stores';
+import wallet from '$lib/stores/wallet';
+import { get } from 'svelte/store';
+import buildUrl from './build-url';
+
+/**
+ * Check if the user currently has their wallet connected. If they do, returns true and
+ * doesn't do anything. If they don't, sends the user to /app, with a backTo query string so
+ * they get back to where they wanted to go after connecting.
+ * @returns True if the user is connected, false if the user isn't (and being re-routed to /app).
+ */
+export default function guardConnected(): boolean {
+  const { connected } = get(wallet);
+
+  if (!connected) {
+    const { pathname } = get(page).url;
+    goto(buildUrl('/app', { backTo: encodeURIComponent(pathname) }), { replaceState: true });
+
+    return false;
+  }
+
+  return true;
+}

--- a/src/routes/app/+layout.svelte
+++ b/src/routes/app/+layout.svelte
@@ -44,6 +44,8 @@
 
     walletConnected = connected;
 
+    balances.setAccounts(derived([streams], ([streams]) => streams.accounts));
+
     if (connected) {
       const addressDriverClient = await getAddressDriverClient();
 
@@ -52,7 +54,6 @@
 
       try {
         await streams.connect((await addressDriverClient.getUserIdByAddress(address)).toString());
-        balances.setAccounts(derived([streams], ([streams]) => streams.accounts));
       } catch (e) {
         if (e instanceof Error) {
           fatalError = {

--- a/src/routes/app/+page.svelte
+++ b/src/routes/app/+page.svelte
@@ -1,40 +1,18 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
+  import { page } from '$app/stores';
+  import LargeEmptyState from '$lib/components/large-empty-state/large-empty-state.svelte';
   import wallet from '$lib/stores/wallet';
-  import Emoji from 'radicle-design-system/Emoji.svelte';
+
+  const backTo = $page.url.searchParams.get('backTo');
 
   $: {
-    if ($wallet.connected) goto('/app/dashboard');
+    if ($wallet.connected) goto(backTo ? decodeURIComponent(backTo) : '/app/dashboard');
   }
 </script>
 
-<div class="welcome-page">
-  <Emoji size="huge" emoji="🌐" />
-  <div class="content">
-    <h1>Connect to Drips</h1>
-    <p>Connect your wallet to view your Dashboard.</p>
-  </div>
-</div>
-
-<style>
-  .welcome-page {
-    height: 100%;
-    padding: 30vh 0;
-    display: flex;
-    justify-content: center;
-    gap: 2rem;
-    flex-direction: column;
-    align-items: center;
-  }
-
-  .content {
-    display: flex;
-    gap: 0.5rem;
-    align-items: center;
-    flex-direction: column;
-  }
-
-  p {
-    color: var(--color-foreground-level-6);
-  }
-</style>
+<LargeEmptyState
+  emoji="🌐"
+  headline="Connect to Drips"
+  description="Connect your wallet to view your Dashboard."
+/>

--- a/src/routes/app/[userId]/+page.svelte
+++ b/src/routes/app/[userId]/+page.svelte
@@ -1,0 +1,180 @@
+<script lang="ts">
+  import { page } from '$app/stores';
+  import IdentityBadge from '$lib/components/identity-badge/identity-badge.svelte';
+  import LargeEmptyState from '$lib/components/large-empty-state/large-empty-state.svelte';
+  import ens from '$lib/stores/ens';
+  import streams from '$lib/stores/streams';
+  import wallet from '$lib/stores/wallet';
+  import { getAddressDriverClient } from '$lib/utils/get-drips-clients';
+  import { isAddress } from 'ethers/lib/utils';
+  import { AddressDriverClient } from 'radicle-drips';
+  import { onMount } from 'svelte';
+  import Balances from '../dashboard/sections/balances.section.svelte';
+  import Splits from '../dashboard/sections/splits.section.svelte';
+  import Streams from '../dashboard/sections/streams.section.svelte';
+  import SocialLink from '$lib/components/social-link/social-link.svelte';
+  import unreachable from '$lib/utils/unreachable';
+  import SectionSkeleton from '$lib/components/section-skeleton/section-skeleton.svelte';
+  import { fade } from 'svelte/transition';
+
+  $: userId = $page.params.userId;
+
+  let dripsUserId: string | undefined;
+  let address: string | undefined;
+  let error: Error | undefined;
+
+  const ensRecords = ['description', 'url', 'com.twitter', 'com.github'] as const;
+  const socialLinks = ['com.twitter', 'com.github', 'url'] as const;
+
+  let socialLinkValues: { [key in typeof socialLinks[number]]: string } | undefined = undefined;
+  let description: string | undefined;
+
+  async function fetchEnsRecords(
+    ensName: string,
+  ): Promise<{ [key in typeof ensRecords[number]]: string } | undefined> {
+    try {
+      const { provider } = $wallet;
+
+      const resolver = await provider.getResolver(ensName);
+
+      const promises = ensRecords.map(async (recordName) => [
+        recordName,
+        await resolver?.getText(recordName),
+      ]);
+
+      const result = Object.fromEntries(await Promise.all(promises));
+
+      return result;
+    } catch {
+      return undefined;
+    }
+  }
+
+  async function updateEnsRecords(name: string) {
+    const records = await fetchEnsRecords(name);
+
+    if (!records) return;
+
+    description = records.description;
+
+    socialLinkValues = {
+      url: records.url,
+      'com.github': records['com.github'],
+      'com.twitter': records['com.twitter'],
+    };
+  }
+
+  onMount(async () => {
+    if (isAddress(userId)) {
+      address = userId;
+      dripsUserId = await (await getAddressDriverClient()).getUserIdByAddress(userId);
+    } else if (/^\d+$/.test(userId)) {
+      // User ID param has only numbers and is probably a drips user ID
+      dripsUserId = userId;
+      address = AddressDriverClient.getUserAddress(userId);
+    } else if (userId.endsWith('.eth')) {
+      const lookup = await ens.reverseLookup(userId);
+      if (lookup) {
+        dripsUserId = await (await getAddressDriverClient()).getUserIdByAddress(lookup);
+        address = lookup;
+      } else {
+        error = new Error('Not found');
+      }
+    } else {
+      error = new Error('Not found.');
+    }
+  });
+
+  $: {
+    const name = address && $ens[address]?.name;
+    if (name) updateEnsRecords(name);
+  }
+
+  function isNetwork(input: string): input is typeof socialLinks[number] {
+    return socialLinks.includes(input as typeof socialLinks[number]);
+  }
+
+  $: dripsUserId && streams.fetchAccount(dripsUserId);
+</script>
+
+<svelte:head>
+  <title>Profile - {(address && $ens[address]?.name) ?? address ?? userId}</title>
+  <meta name="description" value="Radicle Drips Dashboard" />
+</svelte:head>
+
+{#if error}
+  <LargeEmptyState
+    emoji="🕸"
+    headline="Unable to show profile"
+    description="We weren't able to find that profile."
+  />
+{:else}
+  <div class="profile">
+    <SectionSkeleton placeholderOutline={false} loaded={Boolean(address)}>
+      {#if address}
+        <div class="identity">
+          <div class="avatar-and-name">
+            <IdentityBadge disableLink {address} size="gigantic" showIdentity={false} />
+            <IdentityBadge disableLink {address} size="gigantic" showAvatar={false} />
+          </div>
+          <div class="social-links">
+            <div in:fade><SocialLink network="ethereum" value={address} /></div>
+            {#each Object.entries(socialLinkValues ?? {}) as [network, value]}
+              {#if value}<div in:fade>
+                  <SocialLink network={isNetwork(network) ? network : unreachable()} {value} />
+                </div>{/if}
+            {/each}
+          </div>
+          {#if description}<p class="description" in:fade>{description}</p>{/if}
+        </div>
+      {/if}
+    </SectionSkeleton>
+    <Balances userId={dripsUserId} />
+    <Streams userId={dripsUserId} />
+    <Splits userId={dripsUserId} />
+  </div>
+{/if}
+
+<style>
+  .identity {
+    display: flex;
+    gap: 1.5rem;
+    flex-direction: column;
+  }
+
+  .identity > .avatar-and-name {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+  }
+
+  .profile {
+    display: flex;
+    flex-direction: column;
+    gap: 4rem;
+  }
+
+  .social-links {
+    display: flex;
+    gap: 0.5rem;
+    color: var(--color-foreground-level-4);
+    flex-wrap: wrap;
+  }
+
+  .social-links * {
+    display: flex;
+    gap: 0.5rem;
+  }
+  .social-links *:not(:last-child)::after {
+    content: '•';
+  }
+
+  .description {
+    max-width: 40rem;
+    color: var(--color-foreground-level-6);
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+</style>

--- a/src/routes/app/dashboard/+page.svelte
+++ b/src/routes/app/dashboard/+page.svelte
@@ -3,9 +3,9 @@
   import Streams from './sections/streams.section.svelte';
   import Splits from './sections/splits.section.svelte';
 
-  import { goto } from '$app/navigation';
   import wallet from '$lib/stores/wallet';
   import { getAddressDriverClient } from '$lib/utils/get-drips-clients';
+  import guardConnected from '$lib/utils/guard-connected';
 
   let userId: string;
 
@@ -20,9 +20,8 @@
   }
 
   $: {
-    if (!$wallet.connected) {
-      goto('/');
-    }
+    $wallet.connected;
+    guardConnected();
   }
 </script>
 
@@ -33,9 +32,9 @@
 
 <div class="dashboard">
   <h1>Dashboard</h1>
-  <Balances />
-  <Streams />
-  <Splits {userId} />
+  <Balances {userId} disableActions={false} />
+  <Streams {userId} disableActions={false} />
+  <Splits {userId} disableActions={false} />
 </div>
 
 <style>

--- a/src/routes/app/dashboard/sections/edit-splits-flow/edit-splits-inputs.svelte
+++ b/src/routes/app/dashboard/sections/edit-splits-flow/edit-splits-inputs.svelte
@@ -7,7 +7,7 @@
   import type { UserId } from '$lib/stores/streams/types';
   import { getAddressDriverClient, getSubgraphClient } from '$lib/utils/get-drips-clients';
   import TextInput from 'radicle-design-system/TextInput.svelte';
-  import { AddressDriverClient, type AddressDriver } from 'radicle-drips';
+  import { AddressDriverClient, type SplitsReceiverStruct } from 'radicle-drips';
   import Plus from 'radicle-design-system/icons/Plus.svelte';
   import Spinner from '$lib/components/spinner/spinner.svelte';
   import InputAddress from '$lib/components/input-address/input-address.svelte';
@@ -91,7 +91,7 @@
       const client = await getAddressDriverClient();
 
       // format splits for submission
-      const splits: AddressDriver.SplitsReceiverStruct[] = await Promise.all(
+      const splits: SplitsReceiverStruct[] = await Promise.all(
         splitsInputs
           .filter((s) => s.receiver && s.amount)
           .map(async (s) => ({

--- a/src/routes/app/dashboard/sections/splits.section.svelte
+++ b/src/routes/app/dashboard/sections/splits.section.svelte
@@ -26,6 +26,8 @@
     ens: ResolvedRecord;
   }
 
+  export let disableActions = true;
+
   let splitsRaw: SplitsEntry[] | undefined;
   let splits: SplitsRow[] | undefined;
   let error = false;
@@ -121,35 +123,37 @@
     icon={MergeIcon}
     label="Splits"
     actionsDisabled={splits === undefined}
-    actions={[
-      {
-        handler: () => {
-          modal.setHideable(true);
-          modal.show(Stepper, undefined, {
-            steps: [
-              makeStep({
-                component: EditSplitsInputs,
-                props: undefined,
-              }),
-              makeStep({
-                component: SuccessStep,
-                props: {
-                  message: () => {
-                    getSplitsUpdate();
-                    return (
-                      'Your splits have been updated. ' +
-                      'It may take some time to see changes in your dashboard.'
-                    );
-                  },
-                },
-              }),
-            ],
-          });
-        },
-        icon: PenIcon,
-        label: 'Edit',
-      },
-    ]}
+    actions={disableActions
+      ? []
+      : [
+          {
+            handler: () => {
+              modal.setHideable(true);
+              modal.show(Stepper, undefined, {
+                steps: [
+                  makeStep({
+                    component: EditSplitsInputs,
+                    props: undefined,
+                  }),
+                  makeStep({
+                    component: SuccessStep,
+                    props: {
+                      message: () => {
+                        getSplitsUpdate();
+                        return (
+                          'Your splits have been updated. ' +
+                          'It may take some time to see changes in your dashboard.'
+                        );
+                      },
+                    },
+                  }),
+                ],
+              });
+            },
+            icon: PenIcon,
+            label: 'Edit',
+          },
+        ]}
   />
   <div class="content pl-0.5">
     <SectionSkeleton


### PR DESCRIPTION
Adds:
- Profile view at `/app/[id]`, where ID can be either a Drips user ID, ens name, or ethereum address.
- Logic for redirecting the user back to where they came from after being pushed to /app by an `isConnected` route guard.
- Fixes #45

<img width="2088" alt="Screenshot 2022-11-13 at 15 59 49" src="https://user-images.githubusercontent.com/1018218/201528404-5fd6ff11-e3d8-4135-b8ce-8c250ea4cd4e.png">

Todo:

- [x] ENS social account list
- [x] Allow viewing & copying a profile's full address
- [x] E2E Test
- [x] Enable disconnected browsing

Does NOT yet include the ability to browse profiles while not connected to a wallet (for this, we need to wait for the SDK to support providers w/o signers).