### PR TITLE
feat: global advisory store & app init loading state

### DIFF
--- a/src/lib/components/global-advisory/global-advisory.svelte
+++ b/src/lib/components/global-advisory/global-advisory.svelte
@@ -1,0 +1,108 @@
+<script lang="ts">
+  import { browser } from '$app/environment';
+  import type {
+    FatalGlobalAdvisory,
+    NonFatalGlobalAdvisory,
+  } from '$lib/stores/global-advisory/global-advisory.store';
+  import globalErrorStore from '$lib/stores/global-advisory/global-advisory.store';
+  import scroll from '$lib/stores/scroll';
+  import LargeEmptyState from '../large-empty-state/large-empty-state.svelte';
+
+  let fatalAdvisory: FatalGlobalAdvisory | undefined;
+  let nonFatalAdvisories: NonFatalGlobalAdvisory[] = [];
+
+  $: {
+    $globalErrorStore;
+    fatalAdvisory = globalErrorStore.getAdvisories('fatal');
+    nonFatalAdvisories = globalErrorStore.getAdvisories('non-fatal');
+  }
+
+  $: {
+    if (browser && (fatalAdvisory || nonFatalAdvisories[0])) {
+      scroll.lock();
+    } else if (browser) {
+      scroll.unlock();
+    }
+  }
+</script>
+
+{#if fatalAdvisory}
+  <div class="bsod">
+    <h1><span class="white-background">{fatalAdvisory.headline}</span></h1>
+    <div class="description">
+      {#if fatalAdvisory.description}
+        <p>A fatal exception has occurred.</p>
+        <p><i>{fatalAdvisory.description}</i></p>
+      {:else}
+        <p>An unknown fatal exception has occured.</p>
+      {/if}
+      <ul>
+        <li><p>*&#8195&#8195 Press any key to reload this application.</p></li>
+        <li><p>*&#8195&#8195 Ensure your browser is up-to-date.</p></li>
+        <li><p>*&#8195&#8195 Try turning it on & off again.</p></li>
+        <li>
+          *&#8195&#8195<a href="https://discord.gg/vhGXkazpNc" target="_blank"
+            >Get help on our Discord</a
+          >
+        </li>
+      </ul>
+    </div>
+  </div>
+{:else if nonFatalAdvisories[0]}
+  <div class="non-fatal-error">
+    <LargeEmptyState
+      headline={nonFatalAdvisories[0].headline}
+      description={nonFatalAdvisories[0].description}
+      emoji={nonFatalAdvisories[0].emoji}
+    />
+  </div>
+{/if}
+
+<style>
+  .bsod {
+    position: fixed;
+    z-index: 100;
+    height: 100vh;
+    width: 100vw;
+    background-color: #0033bb;
+    color: #fff;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .bsod h1,
+  p,
+  a {
+    font-family: monospace;
+    font-size: 1rem;
+    max-width: 640px;
+  }
+
+  .bsod a {
+    text-decoration: underline;
+  }
+
+  .bsod .white-background {
+    background-color: #fff;
+    color: #0033bb;
+  }
+
+  .bsod .description {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .non-fatal-error {
+    position: fixed;
+    top: 0;
+    left: 0;
+    height: 100vh;
+    width: 100vw;
+    background-color: var(--color-background);
+    z-index: 100;
+  }
+</style>

--- a/src/lib/components/header/header.svelte
+++ b/src/lib/components/header/header.svelte
@@ -23,8 +23,6 @@
     height: 4rem;
     width: 100%;
     background-color: var(--color-background);
-    position: fixed;
-    top: 0;
     transition: box-shadow 0.3s;
     display: flex;
     gap: 1rem;

--- a/src/lib/components/large-empty-state/large-empty-state.svelte
+++ b/src/lib/components/large-empty-state/large-empty-state.svelte
@@ -3,14 +3,14 @@
 
   export let emoji: string;
   export let headline: string;
-  export let description: string;
+  export let description: string | undefined;
 </script>
 
 <div class="large-empty-state">
   <Emoji size="huge" {emoji} />
   <div class="content">
     <h1>{headline}</h1>
-    <p>{description}</p>
+    {#if description}<p>{description}</p>{/if}
     <p />
   </div>
 </div>

--- a/src/lib/stores/global-advisory/global-advisory.store.ts
+++ b/src/lib/stores/global-advisory/global-advisory.store.ts
@@ -1,0 +1,78 @@
+import { get, writable } from 'svelte/store';
+import assert from '$lib/utils/assert';
+
+export interface NonFatalGlobalAdvisory {
+  headline: string;
+  description?: string;
+  emoji: string;
+  fatal: false;
+}
+
+export interface FatalGlobalAdvisory {
+  headline: string;
+  description?: string;
+  fatal: true;
+}
+
+type GlobalAdvisory = NonFatalGlobalAdvisory | FatalGlobalAdvisory;
+
+export default (() => {
+  const errors = writable<{ [handle: number]: GlobalAdvisory }>({});
+
+  /**
+   * Append a new advisory to the global advisory stack, which will be displayed
+   * in a blocking mannger on top of everything else.
+   * @param advisory The advisory to display.
+   * @returns A function you can call in order to resolve the created advisory.
+   */
+  function add(advisory: GlobalAdvisory) {
+    const handle = Object.keys(get(errors)).length;
+    errors.update((state) => ({ ...state, [handle]: advisory }));
+
+    return () => resolve(handle);
+  }
+
+  /**
+   * Resolve an advisory by its handle.
+   * @param handle The handle of the advisory to resolve.
+   */
+  function resolve(handle: number) {
+    const state = get(errors);
+    assert(state[handle], 'Unable to find error with this handle');
+
+    delete state[handle];
+
+    errors.set(state);
+  }
+
+  /** Clear all current advisories. */
+  function clear() {
+    errors.set({});
+  }
+
+  type GetErrorsReturnType<T> = T extends 'fatal'
+    ? FatalGlobalAdvisory | undefined
+    : T extends 'non-fatal'
+    ? NonFatalGlobalAdvisory[]
+    : never;
+
+  /**
+   * Get either the current fatal advisory, or array of non-fatal advisories.
+   * @param type 'fatal' to get the current fatal advisory, if any, and 'non-fatal' to get an array of
+   * current non-fatal advisories.
+   * @returns Either a FatalAdvisory or array of NonFatalAdvisory payloads.
+   */
+  function getAdvisories<T extends 'fatal' | 'non-fatal'>(type: T): GetErrorsReturnType<T> {
+    return type === 'fatal'
+      ? (Object.values(get(errors)).find((error) => error.fatal === true) as GetErrorsReturnType<T>)
+      : (Object.values(get(errors)) as NonFatalGlobalAdvisory[] as GetErrorsReturnType<T>);
+  }
+
+  return {
+    subscribe: errors.subscribe,
+    add,
+    resolve,
+    clear,
+    getAdvisories,
+  };
+})();

--- a/src/routes/app/+layout.svelte
+++ b/src/routes/app/+layout.svelte
@@ -15,23 +15,15 @@
   import PageTransition from '$lib/components/page-transition/page-transition.svelte';
   import { navigating } from '$app/stores';
   import { getAddressDriverClient } from '$lib/utils/get-drips-clients';
+  import globalAdvisoryStore from '$lib/stores/global-advisory/global-advisory.store';
+  import GlobalAdvisory from '$lib/components/global-advisory/global-advisory.svelte';
+  import Spinner from '$lib/components/spinner/spinner.svelte';
+  import { fly } from 'svelte/transition';
 
   export let data: { pathname: string };
 
   let walletConnected = false;
   let loaded = false;
-
-  /**
-   * If a fatal error occurs during store initialization that may result in
-   * incorrect estimation values or balances, this boolean will cause a global
-   * error state to be rendered instead of app content.
-   */
-  let fatalError:
-    | false
-    | {
-        error: unknown;
-        message?: string;
-      } = false;
 
   async function initializeStores() {
     await wallet.initialize();
@@ -56,14 +48,16 @@
         await streams.connect((await addressDriverClient.getUserIdByAddress(address)).toString());
       } catch (e) {
         if (e instanceof Error) {
-          fatalError = {
-            error: e,
-            message: e.message,
-          };
+          globalAdvisoryStore.add({
+            fatal: true,
+            headline: 'A fatal error occured',
+            description: e.message,
+          });
         } else {
-          fatalError = {
-            error: e,
-          };
+          globalAdvisoryStore.add({
+            fatal: true,
+            headline: 'A fatal error occured',
+          });
         }
       }
     } else {
@@ -85,15 +79,6 @@
   });
 
   onMount(() => {
-    const listener = () => {
-      if (fatalError) window.location.reload();
-    };
-
-    window.addEventListener('keydown', listener);
-    return () => window.removeEventListener('keydown', listener);
-  });
-
-  onMount(() => {
     scroll.attach();
     return scroll.detach;
   });
@@ -104,32 +89,10 @@
   });
 </script>
 
-{#if fatalError}
-  <div class="bsod">
-    <h1><span class="white-background">Fatal Error</span></h1>
-    <div class="description">
-      {#if fatalError.message}
-        <p>A fatal exception has occurred.</p>
-        <p><i>{fatalError.message}</i></p>
-      {:else}
-        <p>An unknown fatal exception has occured.</p>
-      {/if}
-      <ul>
-        <li><p>*&#8195&#8195 Press any key to reload this application.</p></li>
-        <li><p>*&#8195&#8195 Ensure your browser is up-to-date.</p></li>
-        <li><p>*&#8195&#8195 Try turning it on & off again.</p></li>
-        <li>
-          *&#8195&#8195<a href="https://discord.gg/vhGXkazpNc" target="_blank"
-            >Get help on our Discord</a
-          >
-        </li>
-      </ul>
-    </div>
-  </div>
-{/if}
+<GlobalAdvisory />
 
-{#if loaded && !fatalError}
-  <div class="main" data-theme={$themeStore.currentTheme}>
+{#if loaded}
+  <div class="main" data-theme={$themeStore.currentTheme} in:fly={{ duration: 300, y: 16 }}>
     <ModalLayout />
     <div class="page" class:loading={$navigating}>
       <PageTransition pathname={data.pathname}>
@@ -138,44 +101,13 @@
     </div>
     <Header />
   </div>
+{:else}
+  <div class="loading-state" out:fly={{ duration: 300, y: -16 }}>
+    <Spinner />
+  </div>
 {/if}
 
 <style>
-  .bsod {
-    height: 100vh;
-    width: 100vw;
-    background-color: #0033bb;
-    color: #fff;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    flex-direction: column;
-    gap: 1rem;
-  }
-
-  .bsod h1,
-  p,
-  a {
-    font-family: monospace;
-    font-size: 1rem;
-    max-width: 640px;
-  }
-
-  .bsod a {
-    text-decoration: underline;
-  }
-
-  .bsod .white-background {
-    background-color: #fff;
-    color: #0033bb;
-  }
-
-  .bsod .description {
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-  }
-
   .page {
     position: relative;
     min-height: 100vh;
@@ -188,5 +120,15 @@
 
   .loading {
     opacity: 0.5s;
+  }
+
+  .loading-state {
+    display: fixed;
+    height: 100vh;
+    width: 100vw;
+    background-color: var(--color-background);
+    display: flex;
+    justify-content: center;
+    align-items: center;
   }
 </style>

--- a/src/routes/app/+layout.svelte
+++ b/src/routes/app/+layout.svelte
@@ -99,6 +99,8 @@
         <slot />
       </PageTransition>
     </div>
+  </div>
+  <div data-theme={$themeStore.currentTheme} class="header" in:fly={{ duration: 300, y: 16 }}>
     <Header />
   </div>
 {:else}
@@ -108,6 +110,12 @@
 {/if}
 
 <style>
+  .header {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+  }
   .page {
     position: relative;
     min-height: 100vh;


### PR DESCRIPTION
Resolves #57

Adds a new "global-advisory" store, which can be used to show full-screen, blocking warnings, or a blue screen of death. Also replaces the blank screen while a wallet connection is restoring on first load with a spinner.