### PR TITLE
feat: tooltip headers in balances section

### DIFF
--- a/src/lib/components/table/table.svelte
+++ b/src/lib/components/table/table.svelte
@@ -8,7 +8,9 @@
   import { createSvelteTable, flexRender, type TableOptions } from '@tanstack/svelte-table';
   import ChevronDown from 'radicle-design-system/icons/ChevronDown.svelte';
   import ChevronUp from 'radicle-design-system/icons/ChevronUp.svelte';
+  import InfoCircle from 'radicle-design-system/icons/InfoCircle.svelte';
   import { createEventDispatcher } from 'svelte';
+  import Tooltip from '../tooltip/tooltip.svelte';
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   export let options: TableOptions<any>;
@@ -41,11 +43,18 @@
           >
             {#if !header.isPlaceholder}
               <div>
-                <span class="typo-all-caps">
-                  {(typeof header.column.columnDef.header === 'string' &&
-                    header.column.columnDef.header) ||
-                    ''}
-                </span>
+                <div class="header">
+                  {#if typeof header.column.columnDef.header === 'string'}
+                    <span class="typo-all-caps">{header.column.columnDef.header}</span>
+                  {/if}
+                  {#if typeof header.column.columnDef.meta === 'object'}
+                    {#if 'tooltipMessage' in header.column.columnDef.meta}
+                      <Tooltip text={header.column.columnDef.meta['tooltipMessage']}>
+                        <InfoCircle style="height: 1rem;" />
+                      </Tooltip>
+                    {/if}
+                  {/if}
+                </div>
                 {#if header.column.getIsSorted() === 'asc'}
                   <ChevronDown />
                 {:else if header.column.getIsSorted() === 'desc'}
@@ -102,6 +111,10 @@
     box-sizing: border-box;
     min-width: 100%;
     --border: 2px solid var(--color-foreground-level-1);
+  }
+
+  .header {
+    display: flex;
   }
 
   tfoot {

--- a/src/lib/components/token-stat/token-stat.svelte
+++ b/src/lib/components/token-stat/token-stat.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
+  import InfoCircle from 'radicle-design-system/icons/InfoCircle.svelte';
+  import Tooltip from '../tooltip/tooltip.svelte';
+
   export let title: string;
+  export let tooltip: string | undefined;
 </script>
 
 <section
@@ -7,7 +11,14 @@
   style="border-color:var(--color-foreground-level-1)"
 >
   <header class="flex flex-wrap justify-between items-end">
-    <h3 class="typo-text-bold">{title}</h3>
+    <div class="title">
+      <h3 class="typo-text-bold">{title}</h3>
+      {#if tooltip}
+        <Tooltip text={tooltip}>
+          <InfoCircle style="height: 1rem;" />
+        </Tooltip>
+      {/if}
+    </div>
     <div>
       <slot name="detail" />
     </div>
@@ -23,3 +34,11 @@
     <slot name="actions" />
   </footer>
 </section>
+
+<style>
+  .title {
+    display: flex;
+    gap: 0.25rem;
+    align-items: center;
+  }
+</style>

--- a/src/lib/components/tooltip/tooltip.svelte
+++ b/src/lib/components/tooltip/tooltip.svelte
@@ -81,7 +81,7 @@
     style:top={`${tooltipPos.top}px`}
   >
     <div class="target-buffer" />
-    <div transition:fly={{ y: 5, duration: 300 }} class="tooltip-content typo-text">
+    <div transition:fly|local={{ y: 5, duration: 300 }} class="tooltip-content typo-text">
       {#if copyable}
         <Copyable alwaysVisible value={text}><span class="content">{text}</span></Copyable>
       {:else}

--- a/src/routes/app/[userId]/tokens/[token]/+page.svelte
+++ b/src/routes/app/[userId]/tokens/[token]/+page.svelte
@@ -103,7 +103,10 @@
     <section class="grid sm:grid-cols-2 gap-3 lg:-mx-4">
       <h2 class="sr-only">Your Balances</h2>
 
-      <TokenStat title="Incoming">
+      <TokenStat
+        title="Incoming"
+        tooltip="Your incoming balance is the cumulative total earned from any incoming streams for this token."
+      >
         <svelte:fragment slot="detail">
           {#if incomingTotals && incomingTotals.amountPerSecond !== 0n}
             <Amount
@@ -131,7 +134,10 @@
         </svelte:fragment>
       </TokenStat>
 
-      <TokenStat title="Outgoing">
+      <TokenStat
+        title="Outgoing"
+        tooltip="Your outgoing balance is the remaining balance you can stream to others for this token."
+      >
         <svelte:fragment slot="detail">
           {#if outgoingEstimate}
             <Amount

--- a/src/routes/app/dashboard/sections/balances.section.svelte
+++ b/src/routes/app/dashboard/sections/balances.section.svelte
@@ -126,7 +126,7 @@
         size: (100 / 24) * 5,
         meta: {
           tooltipMessage:
-            'Your outbound balance is the remaining balance you can stream to others for this token.',
+            'Your outgoing balance is the remaining balance you can stream to others for this token.',
         },
       },
       {

--- a/src/routes/app/dashboard/sections/balances.section.svelte
+++ b/src/routes/app/dashboard/sections/balances.section.svelte
@@ -113,6 +113,10 @@
         cell: () => Amount,
         enableSorting: false,
         size: (100 / 24) * 5,
+        meta: {
+          tooltipMessage:
+            'Your incoming balance is the cumulative total earned from any incoming streams for this token.',
+        },
       },
       {
         accessorKey: 'streaming',
@@ -120,6 +124,10 @@
         cell: () => Amount,
         enableSorting: false,
         size: (100 / 24) * 5,
+        meta: {
+          tooltipMessage:
+            'Your outbound balance is the remaining balance you can stream to others for this token.',
+        },
       },
       {
         accessorKey: 'netRate',


### PR DESCRIPTION
Adds explanatory tooltips for "Incoming" and "Outgoing" balance headers. Copy TBD

<img width="1064" alt="Screenshot 2022-11-25 at 16 01 26" src="https://user-images.githubusercontent.com/1018218/204011556-0d8992f8-0c31-4a01-ba6f-7323f08d5da5.png">

Resolves #80 