### PR TITLE
fix: negative amtPerSec smaller than max decimals shows up as -0

### DIFF
--- a/src/lib/utils/format-token-amount.ts
+++ b/src/lib/utils/format-token-amount.ts
@@ -43,5 +43,5 @@ export default function formatTokenAmount(
       formatted === '-' + (0).toFixed(amountDecimals)) &&
     amount !== 0n;
 
-  return isTiny ? (amount < 0n ? '> -0.00000001' : ' <0.00000001') : formatted;
+  return isTiny ? (amount < 0n ? '- <0.00000001' : ' <0.00000001') : formatted;
 }

--- a/src/lib/utils/format-token-amount.ts
+++ b/src/lib/utils/format-token-amount.ts
@@ -38,7 +38,10 @@ export default function formatTokenAmount(
 
   const formatted = `${parsedAmount.toFixed(amountDecimals)}`;
 
-  const isTiny = formatted === (0).toFixed(amountDecimals) && amount > 0n;
+  const isTiny =
+    (formatted === (0).toFixed(amountDecimals) ||
+      formatted === '-' + (0).toFixed(amountDecimals)) &&
+    amount !== 0n;
 
-  return isTiny ? '<0.00000001' : formatted;
+  return isTiny ? (amount < 0n ? '> -0.00000001' : ' <0.00000001') : formatted;
 }


### PR DESCRIPTION
Best I could come up with is this:

<img width="220" alt="image" src="https://user-images.githubusercontent.com/1018218/205359157-31a414d2-d023-415d-98f2-37391d44e343.png">

