### PR TITLE
fix: mobile search button not updated to new style

### DIFF
--- a/src/lib/components/avatar/avatar.svelte
+++ b/src/lib/components/avatar/avatar.svelte
@@ -24,6 +24,7 @@
 
   img,
   .placeholder {
+    border: 1px solid var(--color-foreground);
     border-radius: 0.75rem;
     position: absolute;
     height: 100%;

--- a/src/lib/components/button/button.svelte
+++ b/src/lib/components/button/button.svelte
@@ -34,6 +34,7 @@
     user-select: none;
     transition: background-color 0.3s, color 0.3s, transform 0.1s, box-shadow 0.3s, opacity 0.3s;
     white-space: nowrap;
+    -webkit-tap-highlight-color: transparent;
   }
 
   button.normal {

--- a/src/lib/components/search-bar/search-bar.svelte
+++ b/src/lib/components/search-bar/search-bar.svelte
@@ -11,6 +11,7 @@
   import tokens from '$lib/stores/tokens';
   import wallet from '$lib/stores/wallet';
   import Results from './components/results.svelte';
+  import Button from '../button/button.svelte';
 
   let focus = false;
   let mobileSearchActive = false;
@@ -170,7 +171,7 @@
     </div>
   {/if}
   <div class="mobile-search-button">
-    <SearchIcon on:click={triggerSearch} />
+    <Button icon={SearchIcon} on:click={triggerSearch} />
   </div>
 </div>
 
@@ -249,16 +250,6 @@
 
   .mobile {
     display: none;
-  }
-
-  .mobile .mobile-search-button {
-    height: 2rem;
-    width: 2rem;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    background-color: var(--color-foreground-level-1);
-    border-radius: 1.5rem 0 1.5rem 1.5rem;
   }
 
   .mobile input {


### PR DESCRIPTION
<img width="388" alt="Screenshot 2022-12-15 at 13 33 03" src="https://user-images.githubusercontent.com/1018218/207860207-f913063c-4365-4232-a597-795309842b8f.png">

Updates the mobile search button to match the new style. Also adds a 1px border around avatars.