### PR TITLE
refactor: transact utility

### DIFF
--- a/src/lib/components/stepper/utils/transact.ts
+++ b/src/lib/components/stepper/utils/transact.ts
@@ -1,0 +1,102 @@
+import modal from '$lib/stores/modal';
+import wallet from '$lib/stores/wallet';
+import etherscanLink from '$lib/utils/etherscan-link';
+import type { ContractReceipt, ContractTransaction } from 'ethers';
+import Emoji from 'radicle-design-system/Emoji.svelte';
+import type { createEventDispatcher } from 'svelte';
+import { get } from 'svelte/store';
+import type { Nullable } from 'vitest';
+import type { StepComponentEvents, UpdateAwaitStepFn, UpdateAwaitStepParams } from '../types';
+
+type BeforeFunc = () => PromiseLike<Record<string, unknown> | void>;
+
+type Context<T> = T extends BeforeFunc ? Awaited<ReturnType<T>> : undefined;
+
+type TransactPayload<T extends Nullable<BeforeFunc>> = {
+  before?: T;
+  transactions: (context: Context<T>) => {
+    transaction: () => Promise<ContractTransaction>;
+    waitingSignatureMessage?: UpdateAwaitStepParams;
+    waitingConfirmationMessage?: UpdateAwaitStepParams;
+  }[];
+  after?: (receipts: ContractReceipt[], context: Context<T>) => PromiseLike<void>;
+  messages?: {
+    duringBefore?: UpdateAwaitStepParams;
+    duringAfter?: UpdateAwaitStepParams;
+  };
+};
+
+export type SomeTransactPayload = <R>(
+  payload: <T extends Nullable<BeforeFunc>>(transactPayload: TransactPayload<T>) => R,
+) => R;
+
+export function makeTransactPayload<T extends Nullable<BeforeFunc>>(
+  i: TransactPayload<T>,
+): SomeTransactPayload {
+  return (cb) => cb(i);
+}
+
+export default function transact(
+  dispatch: ReturnType<typeof createEventDispatcher<StepComponentEvents>>,
+  payload: SomeTransactPayload,
+) {
+  const resolvedPayload = payload((payload) => payload);
+
+  const { before, transactions: transactionsBuilder, after, messages } = resolvedPayload;
+
+  const receipts: ContractReceipt[] = [];
+
+  const promise = async (updateAwaitStep: UpdateAwaitStepFn) => {
+    modal.setHideable(false);
+
+    if (messages?.duringBefore) updateAwaitStep(messages.duringBefore);
+
+    const beforeResult = await before?.();
+
+    const transactions = transactionsBuilder(beforeResult);
+
+    for (const transaction of transactions) {
+      updateAwaitStep(
+        transaction.waitingSignatureMessage ?? {
+          message: 'Waiting for you to sign the transaction in your wallet...',
+          icon: {
+            component: Emoji,
+            props: {
+              emoji: '👛',
+              size: 'huge',
+            },
+          },
+        },
+      );
+
+      const tx = await transaction.transaction();
+
+      updateAwaitStep(
+        transaction.waitingConfirmationMessage ?? {
+          message: 'Waiting for your transaction to be confirmed',
+          link: {
+            url: etherscanLink(get(wallet).network.name, tx.hash),
+            label: 'View on Etherscan',
+          },
+        },
+      );
+
+      receipts.push(await tx.wait(1));
+    }
+
+    updateAwaitStep(
+      messages?.duringAfter ?? {
+        message: 'Wrapping up...',
+      },
+    );
+
+    await after?.(receipts, beforeResult);
+
+    modal.setHideable(true);
+  };
+
+  dispatch('await', {
+    promise: (fn) => promise(fn),
+    message: messages?.duringBefore?.message ?? 'Getting ready...',
+  });
+}

--- a/src/lib/components/stepper/utils/transact.ts
+++ b/src/lib/components/stepper/utils/transact.ts
@@ -13,13 +13,33 @@ type BeforeFunc = () => PromiseLike<Record<string, unknown> | void>;
 type Context<T> = T extends BeforeFunc ? Awaited<ReturnType<T>> : undefined;
 
 type TransactPayload<T extends Nullable<BeforeFunc>> = {
+  /**
+   * Function to run before triggering transactions. You can return an object from this, which
+   * will be made available to both the `transactions` and `after` functions as `context`.
+   */
   before?: T;
+  /**
+   * Function that returns an array of objects, each describing a single transaction that should
+   * be triggered. You can optionally customize the messages the user will see while the transactions
+   * are waiting for signature & confirmation.
+   * @param context Object with optional context returned from `before`.
+   * @returns An array describing all transactions that should be triggered.
+   */
   transactions: (context: Context<T>) => {
     transaction: () => Promise<ContractTransaction>;
     waitingSignatureMessage?: UpdateAwaitStepParams;
     waitingConfirmationMessage?: UpdateAwaitStepParams;
   }[];
+  /**
+   * Function to run after all transactions are confirmed.
+   * @param receipts An array of transaction receipts for all transactions described in `transactions`.
+   * @param context Object with optional context returned from `before`.
+   * @returns
+   */
   after?: (receipts: ContractReceipt[], context: Context<T>) => PromiseLike<void>;
+  /**
+   * Optionally specify cusotm messages that appear while the `before` and `after` steps are executed.
+   */
   messages?: {
     duringBefore?: UpdateAwaitStepParams;
     duringAfter?: UpdateAwaitStepParams;
@@ -36,6 +56,13 @@ export function makeTransactPayload<T extends Nullable<BeforeFunc>>(
   return (cb) => cb(i);
 }
 
+/**
+ * Utility designed for running a standard "sign, wait for confirmation, update UI" pattern within
+ * a stepper flow. Run some logic to prepare one or multiple transactions, execute those transactions,
+ * and then run some logic at the end, before advancing the flow.
+ * @param dispatch The event dispatcher to use for communicating with the stepper.
+ * @param payload Payload for the transact operation. See annotations on the `TransactPayload` type for details.
+ */
 export default function transact(
   dispatch: ReturnType<typeof createEventDispatcher<StepComponentEvents>>,
   payload: SomeTransactPayload,

--- a/src/lib/components/stepper/utils/transact.ts
+++ b/src/lib/components/stepper/utils/transact.ts
@@ -38,7 +38,7 @@ type TransactPayload<T extends Nullable<BeforeFunc>> = {
    */
   after?: (receipts: ContractReceipt[], context: Context<T>) => PromiseLike<void>;
   /**
-   * Optionally specify cusotm messages that appear while the `before` and `after` steps are executed.
+   * Optionally specify custom messages that appear while the `before` and `after` steps are executed.
    */
   messages?: {
     duringBefore?: UpdateAwaitStepParams;

--- a/src/lib/flows/create-stream-flow/input-details.svelte
+++ b/src/lib/flows/create-stream-flow/input-details.svelte
@@ -11,8 +11,7 @@
   import streams from '$lib/stores/streams';
   import { constants } from 'radicle-drips';
   import { createEventDispatcher, onMount } from 'svelte';
-  import type { StepComponentEvents, UpdateAwaitStepFn } from '$lib/components/stepper/types';
-  import modal from '$lib/stores/modal';
+  import type { StepComponentEvents } from '$lib/components/stepper/types';
   import wallet from '$lib/stores/wallet';
   import StreamVisual from '$lib/components/stream-visual/stream-visual.svelte';
   import ListSelect from '$lib/components/list-select/list-select.svelte';
@@ -158,29 +157,20 @@
     timeRangeValid;
 
   function submit() {
-    dispatch('await', {
-      message: 'Preparing to create the stream...',
-      promise: async (updateAwaitStep: UpdateAwaitStepFn) => {
-        modal.setHideable(false);
-
-        await createStream(
-          updateAwaitStep,
-          selectedToken ?? unreachable(),
-          amountPerSecond ?? unreachable(),
-          recipientAddressValue,
-          streamNameValue,
-          $streams.accounts[get(wallet).dripsUserId ?? unreachable()],
-          setStartAndEndDate
-            ? {
-                start: combinedStartDate ?? unreachable(),
-                end: combinedEndDate ?? unreachable(),
-              }
-            : undefined,
-        );
-
-        modal.setHideable(true);
-      },
-    });
+    createStream(
+      dispatch,
+      selectedToken ?? unreachable(),
+      amountPerSecond ?? unreachable(),
+      recipientAddressValue,
+      streamNameValue,
+      $streams.accounts[get(wallet).dripsUserId ?? unreachable()],
+      setStartAndEndDate
+        ? {
+            start: combinedStartDate ?? unreachable(),
+            end: combinedEndDate ?? unreachable(),
+          }
+        : undefined,
+    );
   }
 </script>
 

--- a/src/lib/flows/create-stream-flow/methods/create-stream.ts
+++ b/src/lib/flows/create-stream-flow/methods/create-stream.ts
@@ -1,4 +1,4 @@
-import type { UpdateAwaitStepFn } from '$lib/components/stepper/types';
+import type { StepComponentEvents } from '$lib/components/stepper/types';
 import {
   getAddressDriverClient,
   getCallerClient,
@@ -18,15 +18,15 @@ import {
   type streamMetadataSchema,
 } from '$lib/stores/streams/metadata';
 import type { z } from 'zod';
-import Emoji from '$lib/components/emoji/emoji.svelte';
-import etherscanLink from '$lib/utils/etherscan-link';
 import expect from '$lib/utils/expect';
 import streams from '$lib/stores/streams';
 import mapFilterUndefined from '$lib/utils/map-filter-undefined';
 import randomBigintUntilUnique from '$lib/utils/random-bigint-until-unique';
+import transact, { makeTransactPayload } from '$lib/components/stepper/utils/transact';
+import type { createEventDispatcher } from 'svelte';
 
-export default async (
-  updateAwaitStep: UpdateAwaitStepFn,
+export default function (
+  dispatch: ReturnType<typeof createEventDispatcher<StepComponentEvents>>,
   selectedToken: TokenInfoWrapper,
   amountPerSecond: bigint,
   recipientAddress: string,
@@ -36,146 +36,142 @@ export default async (
     start: Date;
     end: Date;
   },
-) => {
-  const callerClient = await getCallerClient();
-  const addressDriverClient = await getAddressDriverClient();
-  const ownUserId = (await addressDriverClient.getUserId()).toString();
+) {
+  transact(
+    dispatch,
+    makeTransactPayload({
+      before: async () => {
+        const callerClient = await getCallerClient();
+        const addressDriverClient = await getAddressDriverClient();
+        const ownUserId = (await addressDriverClient.getUserId()).toString();
 
-  const { address: tokenAddress } = selectedToken.info;
+        const { address: tokenAddress } = selectedToken.info;
 
-  const assetConfig = ownAccount.assetConfigs.find(
-    (ac) => ac.tokenAddress.toLowerCase() === tokenAddress.toLowerCase(),
-  );
-  assert(assetConfig, "App hasn't yet fetched the right asset config");
+        const assetConfig = ownAccount.assetConfigs.find(
+          (ac) => ac.tokenAddress.toLowerCase() === tokenAddress.toLowerCase(),
+        );
+        assert(assetConfig, "App hasn't yet fetched the right asset config");
 
-  const currentReceivers = mapFilterUndefined(assetConfig.streams, (stream) =>
-    stream.paused
-      ? undefined
-      : {
-          userId: stream.receiver.userId,
-          config: stream.dripsConfig.raw,
+        const currentReceivers = mapFilterUndefined(assetConfig.streams, (stream) =>
+          stream.paused
+            ? undefined
+            : {
+                userId: stream.receiver.userId,
+                config: stream.dripsConfig.raw,
+              },
+        );
+
+        const start = schedule ? BigInt(schedule.start.getTime() / 1000) : 0n;
+
+        const duration = schedule
+          ? BigInt(Math.floor((schedule.end.getTime() - schedule.start.getTime()) / 1000))
+          : 0n;
+
+        const dripId = randomBigintUntilUnique(
+          assetConfig.streams.map((s) => BigInt(decodeStreamId(s.id).dripId)),
+          4,
+        );
+
+        const dripConfig = Utils.DripsReceiverConfiguration.toUint256({
+          dripId,
+          start,
+          duration,
+          amountPerSec: amountPerSecond,
+        });
+
+        const recipientUserId = await addressDriverClient.getUserIdByAddress(recipientAddress);
+        const { address } = get(wallet);
+        assert(address);
+
+        const newStreamMetadata: z.infer<typeof streamMetadataSchema> = {
+          id: makeStreamId(ownUserId, tokenAddress, dripId.toString()),
+          initialDripsConfig: {
+            dripId: dripId.toString(),
+            raw: dripConfig.toString(),
+            startTimestamp: Number(start),
+            durationSeconds: Number(duration),
+            amountPerSecond,
+          },
+          receiver: {
+            userId: recipientUserId.toString(),
+            driver: 'address',
+          },
+          archived: false,
+          name: streamName,
+        };
+
+        const accountMetadata = generateMetadata(ownAccount, address);
+        const currentAssetConfigIndex = accountMetadata.assetConfigs.findIndex(
+          (ac) => ac.tokenAddress.toLowerCase() === tokenAddress.toLowerCase(),
+        );
+
+        if (currentAssetConfigIndex === -1) {
+          accountMetadata.assetConfigs.push({
+            tokenAddress,
+            streams: [newStreamMetadata],
+          });
+        } else {
+          const current = accountMetadata.assetConfigs[currentAssetConfigIndex];
+          accountMetadata.assetConfigs[currentAssetConfigIndex] = {
+            ...current,
+            streams: [...current.streams, newStreamMetadata],
+          };
+        }
+
+        const newHash = await pinAccountMetadata(accountMetadata);
+
+        const { CONTRACT_ADDRESS_DRIVER } = getNetworkConfig();
+
+        const createStreamBatchPreset = AddressDriverPresets.Presets.createNewStreamFlow({
+          driverAddress: CONTRACT_ADDRESS_DRIVER,
+          tokenAddress,
+          currentReceivers,
+          newReceivers: [
+            ...currentReceivers,
+            {
+              config: dripConfig,
+              userId: recipientUserId,
+            },
+          ],
+          userMetadata: [
+            {
+              key: USER_DATA_KEY,
+              value: newHash,
+            },
+          ],
+          balanceDelta: 0,
+          transferToAddress: address,
+        });
+
+        return {
+          createStreamBatchPreset,
+          callerClient,
+          ownUserId,
+          newHash,
+        };
+      },
+
+      transactions: (transactContext) => [
+        {
+          transaction: () =>
+            transactContext.callerClient.callBatched(transactContext.createStreamBatchPreset),
         },
-  );
+      ],
 
-  const start = schedule ? BigInt(schedule.start.getTime() / 1000) : 0n;
-
-  const duration = schedule
-    ? BigInt(Math.floor((schedule.end.getTime() - schedule.start.getTime()) / 1000))
-    : 0n;
-
-  const dripId = randomBigintUntilUnique(
-    assetConfig.streams.map((s) => BigInt(decodeStreamId(s.id).dripId)),
-    4,
-  );
-
-  const dripConfig = Utils.DripsReceiverConfiguration.toUint256({
-    dripId,
-    start,
-    duration,
-    amountPerSec: amountPerSecond,
-  });
-
-  const recipientUserId = await addressDriverClient.getUserIdByAddress(recipientAddress);
-  const { address } = get(wallet);
-  assert(address);
-
-  const newStreamMetadata: z.infer<typeof streamMetadataSchema> = {
-    id: makeStreamId(ownUserId, tokenAddress, dripId.toString()),
-    initialDripsConfig: {
-      dripId: dripId.toString(),
-      raw: dripConfig.toString(),
-      startTimestamp: Number(start),
-      durationSeconds: Number(duration),
-      amountPerSecond,
-    },
-    receiver: {
-      userId: recipientUserId.toString(),
-      driver: 'address',
-    },
-    archived: false,
-    name: streamName,
-  };
-
-  const accountMetadata = generateMetadata(ownAccount, address);
-  const currentAssetConfigIndex = accountMetadata.assetConfigs.findIndex(
-    (ac) => ac.tokenAddress.toLowerCase() === tokenAddress.toLowerCase(),
-  );
-
-  if (currentAssetConfigIndex === -1) {
-    accountMetadata.assetConfigs.push({
-      tokenAddress,
-      streams: [newStreamMetadata],
-    });
-  } else {
-    const current = accountMetadata.assetConfigs[currentAssetConfigIndex];
-    accountMetadata.assetConfigs[currentAssetConfigIndex] = {
-      ...current,
-      streams: [...current.streams, newStreamMetadata],
-    };
-  }
-
-  const newHash = await pinAccountMetadata(accountMetadata);
-
-  const { CONTRACT_ADDRESS_DRIVER } = getNetworkConfig();
-
-  const createStreamBatchPreset = AddressDriverPresets.Presets.createNewStreamFlow({
-    driverAddress: CONTRACT_ADDRESS_DRIVER,
-    tokenAddress,
-    currentReceivers,
-    newReceivers: [
-      ...currentReceivers,
-      {
-        config: dripConfig,
-        userId: recipientUserId,
+      after: async (_, transactContext) => {
+        /*
+      We wait up to five seconds for `refreshUserAccount` to update the user's own
+      account's `lastIpfsHash` to the new hash we just published.
+      */
+        await expect(
+          streams.refreshUserAccount,
+          () =>
+            get(streams).accounts[transactContext.ownUserId].lastIpfsHash ===
+            transactContext.newHash,
+          5000,
+          1000,
+        );
       },
-    ],
-    userMetadata: [
-      {
-        key: USER_DATA_KEY,
-        value: newHash,
-      },
-    ],
-    balanceDelta: 0,
-    transferToAddress: address,
-  });
-
-  const waitingWalletIcon = {
-    component: Emoji,
-    props: {
-      emoji: '👛',
-      size: 'huge',
-    },
-  };
-
-  updateAwaitStep({
-    icon: waitingWalletIcon,
-    message: 'Waiting for you to confirm the transaction in your wallet...',
-  });
-
-  const tx = await callerClient.callBatched(createStreamBatchPreset);
-
-  updateAwaitStep({
-    message: 'Waiting for your transaction to be confirmed…',
-    link: {
-      label: 'View on Etherscan',
-      url: etherscanLink(get(wallet).network.name, tx.hash),
-    },
-  });
-
-  await tx.wait();
-
-  updateAwaitStep({
-    message: 'Wrapping up…',
-  });
-
-  /*
-  We wait up to five seconds for `refreshUserAccount` to update the user's own
-  account's `lastIpfsHash` to the new hash we just published.
-  */
-  await expect(
-    streams.refreshUserAccount,
-    () => get(streams).accounts[ownUserId].lastIpfsHash === newHash,
-    5000,
-    1000,
+    }),
   );
-};
+}

--- a/src/lib/flows/delete-stream-flow/confirm.svelte
+++ b/src/lib/flows/delete-stream-flow/confirm.svelte
@@ -5,7 +5,6 @@
   import StepHeader from '$lib/components/step-header/step-header.svelte';
   import StepLayout from '$lib/components/step-layout/step-layout.svelte';
   import type { StepComponentEvents } from '$lib/components/stepper/types';
-  import modal from '$lib/stores/modal';
   import type { Stream } from '$lib/stores/streams/types';
   import { createEventDispatcher } from 'svelte';
   import deleteStream from './methods/delete-stream';
@@ -15,16 +14,7 @@
   export let stream: Stream;
 
   function startDeleting() {
-    dispatch('await', {
-      promise: async (fn) => {
-        modal.setHideable(false);
-
-        await deleteStream(stream, fn);
-
-        modal.setHideable(true);
-      },
-      message: 'Preparing to delete stream…',
-    });
+    deleteStream(dispatch, stream);
   }
 </script>
 

--- a/src/lib/flows/delete-stream-flow/methods/delete-stream.ts
+++ b/src/lib/flows/delete-stream-flow/methods/delete-stream.ts
@@ -6,110 +6,109 @@ import { get } from 'svelte/store';
 import { generateMetadata, pinAccountMetadata, USER_DATA_KEY } from '$lib/stores/streams/metadata';
 import { AddressDriverPresets, Utils } from 'radicle-drips';
 import assert from '$lib/utils/assert';
-import type { UpdateAwaitStepFn } from '$lib/components/stepper/types';
-import Emoji from '$lib/components/emoji/emoji.svelte';
-import etherscanLink from '$lib/utils/etherscan-link';
-import wallet from '$lib/stores/wallet';
+import type { StepComponentEvents } from '$lib/components/stepper/types';
 import expect from '$lib/utils/expect';
 import { goto } from '$app/navigation';
+import transact, { makeTransactPayload } from '$lib/components/stepper/utils/transact';
+import type { createEventDispatcher } from 'svelte';
 
-export default async function (stream: Stream, updateAwaitStep: UpdateAwaitStepFn) {
-  const callerClient = await getCallerClient();
+export default function (
+  dispatch: ReturnType<typeof createEventDispatcher<StepComponentEvents>>,
+  stream: Stream,
+) {
+  transact(
+    dispatch,
+    makeTransactPayload({
+      before: async () => {
+        const callerClient = await getCallerClient();
 
-  const { userId, address } = stream.sender;
-  const { tokenAddress } = stream.dripsConfig.amountPerSecond;
+        const { userId, address } = stream.sender;
+        const { tokenAddress } = stream.dripsConfig.amountPerSecond;
 
-  const assetConfig = streams.getAssetConfig(userId, tokenAddress);
-  assert(assetConfig, "App hasn't yet fetched the right asset config for this stream");
+        const assetConfig = streams.getAssetConfig(userId, tokenAddress);
+        assert(assetConfig, "App hasn't yet fetched the right asset config for this stream");
 
-  const ownAccount = get(streams).accounts[userId];
-  assert(assetConfig, "App hasn't yet fetched user's own account");
+        const ownAccount = get(streams).accounts[userId];
+        assert(assetConfig, "App hasn't yet fetched user's own account");
 
-  const metadata = generateMetadata(ownAccount, address);
-  const assetConfigIndex = metadata.assetConfigs.findIndex(
-    (mac) => mac.tokenAddress.toLowerCase() === tokenAddress.toLowerCase(),
-  );
-  const streamIndex = metadata.assetConfigs[assetConfigIndex].streams.findIndex(
-    (ms) => ms.id === stream.id,
-  );
+        const metadata = generateMetadata(ownAccount, address);
+        const assetConfigIndex = metadata.assetConfigs.findIndex(
+          (mac) => mac.tokenAddress.toLowerCase() === tokenAddress.toLowerCase(),
+        );
+        const streamIndex = metadata.assetConfigs[assetConfigIndex].streams.findIndex(
+          (ms) => ms.id === stream.id,
+        );
 
-  metadata.assetConfigs[assetConfigIndex].streams.splice(streamIndex, 1);
+        metadata.assetConfigs[assetConfigIndex].streams.splice(streamIndex, 1);
 
-  if (metadata.assetConfigs[assetConfigIndex].streams.length === 0) {
-    metadata.assetConfigs.splice(assetConfigIndex, 1);
-  }
+        if (metadata.assetConfigs[assetConfigIndex].streams.length === 0) {
+          metadata.assetConfigs.splice(assetConfigIndex, 1);
+        }
 
-  const newHash = await pinAccountMetadata(metadata);
+        const newHash = await pinAccountMetadata(metadata);
 
-  const currentReceivers = mapFilterUndefined(assetConfig.streams, (stream) =>
-    stream.paused
-      ? undefined
-      : {
-          userId: stream.receiver.userId,
-          config: stream.dripsConfig.raw,
+        const currentReceivers = mapFilterUndefined(assetConfig.streams, (stream) =>
+          stream.paused
+            ? undefined
+            : {
+                userId: stream.receiver.userId,
+                config: stream.dripsConfig.raw,
+              },
+        );
+
+        const newReceivers = currentReceivers.filter(
+          (r) =>
+            Utils.DripsReceiverConfiguration.fromUint256(r.config).dripId.toString() !==
+            stream.dripsConfig.dripId,
+        );
+
+        const { CONTRACT_ADDRESS_DRIVER } = getNetworkConfig();
+
+        const createStreamBatchPreset = AddressDriverPresets.Presets.createNewStreamFlow({
+          driverAddress: CONTRACT_ADDRESS_DRIVER,
+          tokenAddress,
+          currentReceivers,
+          newReceivers,
+          userMetadata: [
+            {
+              key: USER_DATA_KEY,
+              value: newHash,
+            },
+          ],
+          balanceDelta: 0,
+          transferToAddress: address,
+        });
+
+        return {
+          callerClient,
+          createStreamBatchPreset,
+          userId,
+          newHash,
+        };
+      },
+
+      transactions: (transactContext) => [
+        {
+          transaction: () =>
+            transactContext.callerClient.callBatched(transactContext.createStreamBatchPreset),
         },
-  );
+      ],
 
-  const newReceivers = currentReceivers.filter(
-    (r) =>
-      Utils.DripsReceiverConfiguration.fromUint256(r.config).dripId.toString() !==
-      stream.dripsConfig.dripId,
-  );
+      after: async (_, transactContext) => {
+        /*
+      We wait up to five seconds for `refreshUserAccount` to update the user's own
+      account's `lastIpfsHash` to the new hash we just published.
+      */
+        await expect(
+          streams.refreshUserAccount,
+          () =>
+            get(streams).accounts[transactContext.userId].lastIpfsHash === transactContext.newHash,
+          5000,
+          1000,
+        );
 
-  const { CONTRACT_ADDRESS_DRIVER } = getNetworkConfig();
-
-  const createStreamBatchPreset = AddressDriverPresets.Presets.createNewStreamFlow({
-    driverAddress: CONTRACT_ADDRESS_DRIVER,
-    tokenAddress,
-    currentReceivers,
-    newReceivers,
-    userMetadata: [
-      {
-        key: USER_DATA_KEY,
-        value: newHash,
+        goto('/app/dashboard');
       },
-    ],
-    balanceDelta: 0,
-    transferToAddress: address,
-  });
-
-  updateAwaitStep({
-    icon: {
-      component: Emoji,
-      props: {
-        emoji: '👛',
-        size: 'huge',
-      },
-    },
-    message: 'Waiting for you to confirm the transaction in your wallet...',
-  });
-
-  const tx = await callerClient.callBatched(createStreamBatchPreset);
-
-  updateAwaitStep({
-    message: 'Waiting for your transaction to be confirmed…',
-    link: {
-      label: 'View on Etherscan',
-      url: etherscanLink(get(wallet).network.name, tx.hash),
-    },
-  });
-
-  await tx.wait();
-
-  updateAwaitStep({
-    message: 'Wrapping up…',
-  });
-
-  /*
-  We wait up to five seconds for `refreshUserAccount` to update the user's own
-  account's `lastIpfsHash` to the new hash we just published.
-  */
-  await expect(
-    streams.refreshUserAccount,
-    () => get(streams).accounts[userId].lastIpfsHash === newHash,
-    5000,
-    1000,
+    }),
   );
-
-  goto('/app/dashboard');
 }

--- a/src/lib/flows/pause-flow/pause.svelte
+++ b/src/lib/flows/pause-flow/pause.svelte
@@ -5,102 +5,81 @@
   import { getAddressDriverClient } from '$lib/utils/get-drips-clients';
   import type { Stream } from '$lib/stores/streams/types';
   import streams from '$lib/stores/streams';
-  import type { StepComponentEvents, UpdateAwaitStepFn } from '$lib/components/stepper/types';
-  import Emoji from '$lib/components/emoji/emoji.svelte';
-  import etherscanLink from '$lib/utils/etherscan-link';
+  import type { StepComponentEvents } from '$lib/components/stepper/types';
   import expect from '$lib/utils/expect';
   import mapFilterUndefined from '$lib/utils/map-filter-undefined';
-  import modal from '$lib/stores/modal';
+  import transact, { makeTransactPayload } from '$lib/components/stepper/utils/transact';
 
   const dispatch = createEventDispatcher<StepComponentEvents>();
 
   export let stream: Stream;
 
-  async function pause(updateAwaitStep: UpdateAwaitStepFn) {
-    modal.setHideable(false);
+  onMount(() => {
+    transact(
+      dispatch,
+      makeTransactPayload({
+        before: async () => {
+          const { dripsUserId, address } = $wallet;
+          assert(dripsUserId && address);
 
-    const { dripsUserId, address } = $wallet;
-    assert(dripsUserId && address);
+          const addressDriverClient = await getAddressDriverClient();
 
-    const addressDriverClient = await getAddressDriverClient();
+          const { tokenAddress } = stream.dripsConfig.amountPerSecond;
 
-    const { tokenAddress } = stream.dripsConfig.amountPerSecond;
+          const ownAccount = $streams.accounts[dripsUserId];
+          assert(ownAccount, "App hasn't yet fetched user's own account");
 
-    const ownAccount = $streams.accounts[dripsUserId];
-    assert(ownAccount, "App hasn't yet fetched user's own account");
+          const assetConfig = ownAccount.assetConfigs.find(
+            (ac) => ac.tokenAddress.toLowerCase() === tokenAddress.toLowerCase(),
+          );
+          assert(assetConfig, "App hasn't yet fetched the right asset config");
 
-    const assetConfig = ownAccount.assetConfigs.find(
-      (ac) => ac.tokenAddress.toLowerCase() === tokenAddress.toLowerCase(),
-    );
-    assert(assetConfig, "App hasn't yet fetched the right asset config");
+          const currentReceivers = mapFilterUndefined(assetConfig.streams, (stream) =>
+            stream.paused
+              ? undefined
+              : {
+                  userId: stream.receiver.userId,
+                  config: stream.dripsConfig.raw,
+                },
+          );
 
-    const currentReceivers = mapFilterUndefined(assetConfig.streams, (stream) =>
-      stream.paused
-        ? undefined
-        : {
+          const newStreams = assetConfig.streams.filter((s) => s.id !== stream.id);
+
+          const newReceivers = newStreams.map((stream) => ({
             userId: stream.receiver.userId,
             config: stream.dripsConfig.raw,
-          },
-    );
+          }));
 
-    const newStreams = assetConfig.streams.filter((s) => s.id !== stream.id);
+          const tx = addressDriverClient.setDrips(
+            tokenAddress,
+            currentReceivers,
+            newReceivers,
+            address,
+            0,
+          );
 
-    const newReceivers = newStreams.map((stream) => ({
-      userId: stream.receiver.userId,
-      config: stream.dripsConfig.raw,
-    }));
-
-    updateAwaitStep({
-      icon: {
-        component: Emoji,
-        props: {
-          emoji: '👛',
-          size: 'huge',
+          return { tx };
         },
-      },
-      message: 'Waiting for you to confirm the pause transaction in your wallet...',
-    });
 
-    const tx = await addressDriverClient.setDrips(
-      tokenAddress,
-      currentReceivers,
-      newReceivers,
-      address,
-      0,
+        transactions: (transactContext) => [
+          {
+            transaction: () => transactContext.tx,
+          },
+        ],
+
+        after: async () => {
+          /*
+        We wait up to five seconds for `refreshUserAccount` to update the user's own
+        account's `lastIpfsHash` to the new hash we just published.
+        */
+          await expect(
+            streams.refreshUserAccount,
+            () => streams.getStreamById(stream.id)?.paused === true,
+            5000,
+            1000,
+          );
+        },
+      }),
     );
-
-    updateAwaitStep({
-      message: 'Waiting for your transaction to be confirmed…',
-      link: {
-        label: 'View on Etherscan',
-        url: etherscanLink($wallet.network.name, tx.hash),
-      },
-    });
-
-    await tx.wait(1);
-
-    updateAwaitStep({
-      message: 'Wrapping up…',
-    });
-
-    /*
-    We wait up to five seconds for `refreshUserAccount` to update the user's own
-    account's `lastIpfsHash` to the new hash we just published.
-    */
-    await expect(
-      streams.refreshUserAccount,
-      () => streams.getStreamById(stream.id)?.paused === true,
-      5000,
-      1000,
-    );
-
-    modal.setHideable(true);
-  }
-
-  onMount(() => {
-    dispatch('await', {
-      promise: (fn) => pause(fn),
-      message: 'Preparing to pause stream…',
-    });
   });
 </script>

--- a/src/lib/flows/top-up-flow/approve.svelte
+++ b/src/lib/flows/top-up-flow/approve.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import StepHeader from '$lib/components/step-header/step-header.svelte';
   import StepLayout from '$lib/components/step-layout/step-layout.svelte';
-  import type { StepComponentEvents, UpdateAwaitStepFn } from '$lib/components/stepper/types';
+  import type { StepComponentEvents } from '$lib/components/stepper/types';
   import tokens from '$lib/stores/tokens';
   import type { Writable } from 'svelte/store';
   import { createEventDispatcher } from 'svelte';
@@ -9,10 +9,8 @@
   import { getAddressDriverClient } from '$lib/utils/get-drips-clients';
   import { ethers } from 'ethers';
   import Button from '$lib/components/button/button.svelte';
-  import modal from '$lib/stores/modal';
-  import Emoji from '$lib/components/emoji/emoji.svelte';
-  import etherscanLink from '$lib/utils/etherscan-link';
-  import wallet from '$lib/stores/wallet';
+  import transact, { makeTransactPayload } from '$lib/components/stepper/utils/transact';
+  import unreachable from '$lib/utils/unreachable';
 
   const dispatch = createEventDispatcher<StepComponentEvents>();
 
@@ -21,42 +19,24 @@
   $: tokenAddress = $context.tokenAddress;
   $: tokenInfo = tokenAddress ? tokens.getByAddress(tokenAddress) : undefined;
 
-  async function approve(updateAwaitStep: UpdateAwaitStepFn) {
-    if (!tokenAddress) throw new Error('Undefined token address on approve step');
-    const tx = await (await getAddressDriverClient()).approve(tokenAddress);
-
-    updateAwaitStep({
-      message: 'Waiting for the approval transaction to be confirmed…',
-      link: {
-        label: 'View on Etherscan',
-        url: etherscanLink($wallet.network.name, tx.hash),
-      },
-    });
-
-    await tx.wait();
-
-    context.update((c) => ({
-      ...c,
-      tokenAllowance: ethers.constants.MaxUint256.toBigInt(),
-    }));
-
-    modal.setHideable(true);
-  }
-
   function submit() {
-    modal.setHideable(false);
-
-    dispatch('await', {
-      message: 'Waiting for you to confirm the approval transaction in your wallet',
-      icon: {
-        component: Emoji,
-        props: {
-          emoji: '👛',
-          size: 'huge',
+    transact(
+      dispatch,
+      makeTransactPayload({
+        transactions: () => [
+          {
+            transaction: async () =>
+              (await getAddressDriverClient()).approve(tokenAddress ?? unreachable()),
+          },
+        ],
+        after: async () => {
+          context.update((c) => ({
+            ...c,
+            tokenAllowance: ethers.constants.MaxUint256.toBigInt(),
+          }));
         },
-      },
-      promise: approve,
-    });
+      }),
+    );
   }
 </script>
 

--- a/src/lib/flows/unpause-flow/unpause.svelte
+++ b/src/lib/flows/unpause-flow/unpause.svelte
@@ -5,99 +5,78 @@
   import { getAddressDriverClient } from '$lib/utils/get-drips-clients';
   import type { Stream } from '$lib/stores/streams/types';
   import streams from '$lib/stores/streams';
-  import type { StepComponentEvents, UpdateAwaitStepFn } from '$lib/components/stepper/types';
-  import Emoji from '$lib/components/emoji/emoji.svelte';
-  import etherscanLink from '$lib/utils/etherscan-link';
+  import type { StepComponentEvents } from '$lib/components/stepper/types';
   import expect from '$lib/utils/expect';
   import mapFilterUndefined from '$lib/utils/map-filter-undefined';
-  import modal from '$lib/stores/modal';
+  import transact, { makeTransactPayload } from '$lib/components/stepper/utils/transact';
 
   const dispatch = createEventDispatcher<StepComponentEvents>();
 
   export let stream: Stream;
 
-  async function pause(updateAwaitStep: UpdateAwaitStepFn) {
-    modal.setHideable(false);
-
-    const { dripsUserId, address } = $wallet;
-    assert(dripsUserId && address);
-
-    const addressDriverClient = await getAddressDriverClient();
-
-    const { tokenAddress } = stream.dripsConfig.amountPerSecond;
-
-    const ownAccount = $streams.accounts[dripsUserId];
-    assert(ownAccount, "App hasn't yet fetched user's own account");
-
-    const assetConfig = ownAccount.assetConfigs.find(
-      (ac) => ac.tokenAddress.toLowerCase() === tokenAddress.toLowerCase(),
-    );
-    assert(assetConfig, "App hasn't yet fetched the right asset config");
-
-    const currentReceivers = mapFilterUndefined(assetConfig.streams, (stream) =>
-      stream.paused
-        ? undefined
-        : {
-            userId: stream.receiver.userId,
-            config: stream.dripsConfig.raw,
-          },
-    );
-
-    const newReceivers = [
-      ...currentReceivers,
-      {
-        userId: stream.receiver.userId,
-        config: stream.dripsConfig.raw,
-      },
-    ];
-
-    updateAwaitStep({
-      icon: {
-        component: Emoji,
-        props: {
-          emoji: '👛',
-          size: 'huge',
-        },
-      },
-      message: 'Waiting for you to confirm the un-pause transaction in your wallet...',
-    });
-
-    const tx = await addressDriverClient.setDrips(
-      tokenAddress,
-      currentReceivers,
-      newReceivers,
-      address,
-      0,
-    );
-
-    updateAwaitStep({
-      message: 'Waiting for your transaction to be confirmed…',
-      link: {
-        label: 'View on Etherscan',
-        url: etherscanLink($wallet.network.name, tx.hash),
-      },
-    });
-
-    await tx.wait(1);
-
-    updateAwaitStep({
-      message: 'Wrapping up…',
-    });
-
-    await expect(
-      streams.refreshUserAccount,
-      () => streams.getStreamById(stream.id)?.paused === false,
-      5000,
-      1000,
-    );
-
-    modal.setHideable(true);
-  }
-
   onMount(() => {
-    dispatch('await', {
-      promise: (fn) => pause(fn),
-      message: 'Preparing to un-pause stream…',
-    });
+    transact(
+      dispatch,
+      makeTransactPayload({
+        before: async () => {
+          const { dripsUserId, address } = $wallet;
+          assert(dripsUserId && address);
+
+          const addressDriverClient = await getAddressDriverClient();
+
+          const { tokenAddress } = stream.dripsConfig.amountPerSecond;
+
+          const ownAccount = $streams.accounts[dripsUserId];
+          assert(ownAccount, "App hasn't yet fetched user's own account");
+
+          const assetConfig = ownAccount.assetConfigs.find(
+            (ac) => ac.tokenAddress.toLowerCase() === tokenAddress.toLowerCase(),
+          );
+          assert(assetConfig, "App hasn't yet fetched the right asset config");
+
+          const currentReceivers = mapFilterUndefined(assetConfig.streams, (stream) =>
+            stream.paused
+              ? undefined
+              : {
+                  userId: stream.receiver.userId,
+                  config: stream.dripsConfig.raw,
+                },
+          );
+
+          const newReceivers = [
+            ...currentReceivers,
+            {
+              userId: stream.receiver.userId,
+              config: stream.dripsConfig.raw,
+            },
+          ];
+
+          const tx = addressDriverClient.setDrips(
+            tokenAddress,
+            currentReceivers,
+            newReceivers,
+            address,
+            0,
+          );
+
+          return { tx };
+        },
+
+        transactions: (transactContext) => [
+          {
+            transaction: () => transactContext.tx,
+          },
+        ],
+
+        after: async () => {
+          await expect(
+            streams.refreshUserAccount,
+            () => streams.getStreamById(stream.id)?.paused === false,
+            5000,
+            1000,
+          );
+        },
+      }),
+    );
   });
 </script>


### PR DESCRIPTION
Introduces a new stepper utility `transact`, which standardises the "sign, wait for confirmation, update UI" pattern we're using in every flow that triggers a transaction. The utility supports multiple transactions too, which are triggered one after the other.

All this is in preparation for #273, and will make it a lot easier to make our app a full Safe App.