### PR TITLE
fix: wrong start date timestamp in some situations

### DIFF
--- a/src/lib/stores/streams/methods/build-asset-configs.ts
+++ b/src/lib/stores/streams/methods/build-asset-configs.ts
@@ -29,7 +29,7 @@ function mapReceiverToStream(
       },
       startDate:
         initialDripsConfig.startTimestamp && initialDripsConfig.startTimestamp > 0
-          ? new Date(initialDripsConfig.startTimestamp)
+          ? new Date(initialDripsConfig.startTimestamp * 1000)
           : undefined,
       durationSeconds:
         initialDripsConfig.durationSeconds !== 0 ? initialDripsConfig.durationSeconds : undefined,

--- a/src/lib/stores/streams/methods/build-asset-configs.ts
+++ b/src/lib/stores/streams/methods/build-asset-configs.ts
@@ -133,7 +133,7 @@ export default function buildAssetConfigs(
 
         /*
         If a particular stream doesn't appear within dripsReceiverSeenEvents of a given
-        dripsSet event, we can assume it is paused.
+        dripsSet event, but did at least once before, we can assume it is paused.
         */
         for (const remainingStreamId of remainingStreamIds) {
           const stream = assetConfigMetadata?.streams.find(
@@ -141,16 +141,22 @@ export default function buildAssetConfigs(
           );
           if (!stream) break;
 
-          assetConfigHistoryItemStreams.push({
-            streamId: remainingStreamId,
-            // Undefined dripsConfig == stream was paused
-            dripsConfig: undefined,
-            managed: true,
-            receiver: {
-              ...stream.receiver,
-              address: AddressDriverClient.getUserAddress(stream.receiver.userId),
-            },
-          });
+          const streamExistedBefore = assetConfigHistoryItems.find((item) =>
+            item.streams.find((stream) => stream.streamId === remainingStreamId),
+          );
+
+          if (streamExistedBefore) {
+            assetConfigHistoryItemStreams.push({
+              streamId: remainingStreamId,
+              // Undefined dripsConfig == stream was paused
+              dripsConfig: undefined,
+              managed: true,
+              receiver: {
+                ...stream.receiver,
+                address: AddressDriverClient.getUserAddress(stream.receiver.userId),
+              },
+            });
+          }
         }
 
         let runsOutOfFunds: Date | undefined;


### PR DESCRIPTION
Fixes two issues:

- Paused, non-scheduled streams may show a completely wrong start date on the stream detail view.
- If a stream is created after the first DripsSetEvent for the given asset config, the app wrongly assumes that the stream had been paused since the very first DripsSetEvent ever published for the same asset config. Now, it only creates paused streams in an AssetConfig's history if the stream had existed ever before.

TODO: Test cases for both the above issues

Resolves #300 
Resolves #299

