### PR TITLE
feat: #296

### DIFF
--- a/src/lib/flows/create-stream-flow/input-details.svelte
+++ b/src/lib/flows/create-stream-flow/input-details.svelte
@@ -32,6 +32,8 @@
 
   const dispatch = createEventDispatcher<StepComponentEvents>();
 
+  export let tokenAddress: string | undefined = undefined;
+
   const userId = $wallet.dripsUserId ?? unreachable();
 
   let streamNameValue: string;
@@ -58,7 +60,7 @@
         if (!token) return undefined;
 
         return [
-          token.info.address,
+          token.info.address.toLowerCase(),
           {
             type: 'selectable',
             label: token.info.name,
@@ -77,10 +79,16 @@
     ) ?? [],
   );
 
-  let selectedTokenAddress: string[] = tokenList ? [Object.keys(tokenList)[0]] : [];
-  onMount(() => {
-    const firstToken = Object.keys(tokenList ?? {})[0];
+  let selectedTokenAddress: string[] = tokenAddress
+    ? [tokenAddress.toLowerCase()]
+    : tokenList
+    ? [Object.keys(tokenList)[0]]
+    : [];
 
+  onMount(() => {
+    if (selectedTokenAddress.length !== 0) return;
+
+    const firstToken = Object.keys(tokenList ?? {})[0];
     if (firstToken) selectedTokenAddress = [firstToken];
   });
 

--- a/src/routes/app/dashboard/sections/streams.section.svelte
+++ b/src/routes/app/dashboard/sections/streams.section.svelte
@@ -260,7 +260,9 @@
                 steps: [
                   makeStep({
                     component: InputDetails,
-                    props: undefined,
+                    props: {
+                      tokenAddress,
+                    },
                   }),
                   makeStep({
                     component: SuccessStep,


### PR DESCRIPTION
When clicking "Create Stream" on a token page, the create stream modal now has the same token pre-selected, instead of always the first one in the tokens list.

resolves #296 