### PR TITLE
fix: #95, fix: #130

### DIFF
--- a/src/lib/stores/streams/metadata.ts
+++ b/src/lib/stores/streams/metadata.ts
@@ -110,6 +110,8 @@ export async function pinAccountMetadata(data: z.infer<typeof accountMetadataSch
     ),
   });
 
+  if (!res.ok) throw new Error(`Pinning new account metadata failed: ${await res.text()}`);
+
   return res.text();
 }
 

--- a/src/routes/api/ipfs/pin/+server.ts
+++ b/src/routes/api/ipfs/pin/+server.ts
@@ -1,16 +1,25 @@
 import 'dotenv/config';
 import pinataSdk from '@pinata/sdk';
-import type { RequestEvent, RequestHandler } from '@sveltejs/kit';
+import { error, type RequestEvent, type RequestHandler } from '@sveltejs/kit';
 import getEnvVar from '$lib/utils/get-env-var';
+import { accountMetadataSchema } from '$lib/stores/streams/metadata';
 
 const pinata = pinataSdk(getEnvVar('PINATA_SDK_KEY'), getEnvVar('PINATA_SDK_SECRET'));
 
 export const POST: RequestHandler = async ({ request }: RequestEvent) => {
-  const res = await pinata.pinJSONToIPFS(await request.json(), {
-    pinataOptions: {
-      cidVersion: 0,
-    },
-  });
+  try {
+    const json = await request.json();
 
-  return new Response(res.IpfsHash);
+    accountMetadataSchema.parse(json);
+
+    const res = await pinata.pinJSONToIPFS(json, {
+      pinataOptions: {
+        cidVersion: 0,
+      },
+    });
+
+    return new Response(res.IpfsHash);
+  } catch (e) {
+    throw error(500, "This doesn't seem to be valid account metadata 🤨");
+  }
 };


### PR DESCRIPTION
Locks down /api/ipfs/pin endpoint so that it can only be used for valid account metadata. Also now explicitly throws an error in user flows if pinning metadata fails for whatever reason.