### PR TITLE
fix: streams missing in current cycle estimate

### DIFF
--- a/src/lib/stores/balances/utils/estimate.ts
+++ b/src/lib/stores/balances/utils/estimate.ts
@@ -100,7 +100,8 @@ export function estimateAssetConfig(
   // Filter out any history items not relevant to the current time window.
   const relevantHistoryItems = assetConfig.history.filter((hi) => {
     const timestamp = hi.timestamp.getTime();
-    const nextTimestamp = assetConfig.history[assetConfig.history.indexOf(hi)]?.timestamp.getTime();
+    const nextTimestamp =
+      assetConfig.history[assetConfig.history.indexOf(hi) + 1]?.timestamp.getTime();
 
     const startsWithinWindow = timestamp <= window.to && timestamp >= window.from;
     const windowIsAfterLastEvent = !nextTimestamp && timestamp < window.from;


### PR DESCRIPTION
There was a typo here that caused streams to not be included in the current cycle estimate if they were created before the current cycle began.