### PR TITLE
feat: soft launch adjustments

### DIFF
--- a/src/lib/components/account-menu/account-menu.svelte
+++ b/src/lib/components/account-menu/account-menu.svelte
@@ -59,7 +59,10 @@
         >
       </li>
       <li>
-        Supported by <a href="https://radicle.xyz" target="_blank" rel="noreferrer">Radicle</a>
+        <a href="/legal/privacy" target="_blank" rel="noreferrer">Privacy</a>
+      </li>
+      <li>
+        <a href="/legal/disclaimer" target="_blank" rel="noreferrer">Disclaimer</a>
       </li>
     </ul>
   {/if}
@@ -77,6 +80,7 @@
     padding: 0.5rem;
     display: flex;
     gap: 0.5rem;
+    flex-wrap: wrap;
   }
 
   .links > li {

--- a/src/lib/components/account-menu/account-menu.svelte
+++ b/src/lib/components/account-menu/account-menu.svelte
@@ -64,6 +64,9 @@
       <li>
         <a href="/legal/disclaimer" target="_blank" rel="noreferrer">Disclaimer</a>
       </li>
+      <li>
+        <a href="/legal/access" target="_blank" rel="noreferrer">Access</a>
+      </li>
     </ul>
   {/if}
 </div>

--- a/src/lib/components/beta-badge/beta-badge.svelte
+++ b/src/lib/components/beta-badge/beta-badge.svelte
@@ -1,0 +1,14 @@
+<h5 class="beta-notice">Beta</h5>
+
+<style>
+  .beta-notice {
+    background-color: var(--color-caution-level-2);
+    padding: 0.125rem 0.625rem 0.125rem 0.75rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 2rem 0 2rem 2rem;
+    user-select: none;
+    color: var(--color-caution-level-6);
+  }
+</style>

--- a/src/lib/components/header/header.svelte
+++ b/src/lib/components/header/header.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import scroll from '$lib/stores/scroll';
   import wallet from '$lib/stores/wallet/wallet.store';
+  import BetaBadge from '../beta-badge/beta-badge.svelte';
   import ConnectButton from '../connect-button/connect-button.svelte';
   import SearchBar from '../search-bar/search-bar.svelte';
   import DripsLogo from '././drips-logo.svelte';
@@ -11,6 +12,7 @@
 <header class:elevated>
   <a href={$wallet.connected ? '/app/dashboard' : '/'}>
     <DripsLogo />
+    <BetaBadge />
   </a>
   <SearchBar />
   <div class="wallet">
@@ -29,6 +31,11 @@
     align-items: center;
     justify-content: space-between;
     padding: 1rem;
+  }
+
+  a {
+    display: flex;
+    gap: 0.5rem;
   }
 
   header.elevated {

--- a/src/lib/stores/scroll/scroll.store.ts
+++ b/src/lib/stores/scroll/scroll.store.ts
@@ -15,7 +15,10 @@ const INITIAL_STATE = {
   scrolling: false,
 };
 
-const store = writable<ScrollStore>(INITIAL_STATE);
+const store = writable<ScrollStore>({
+  ...INITIAL_STATE,
+  pos: browser ? Math.max(window.scrollY, 0) : 0,
+});
 
 const html = browser && document.querySelector('html');
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -28,9 +28,9 @@
   />
 </svelte:head>
 
-<div id="lp" class="loaded">
+<LpHeader />
+<div id="lp">
   <div id="wrapper">
-    <LpHeader />
     <section id="hero">
       <div id="hero-illustration">
         <BigDripsLogo />
@@ -287,8 +287,6 @@
     --font-size-m: 1.5rem;
     --font-size-l: 2.5rem;
     --font-size-xl: 3rem;
-
-    animation: intro 0.5s;
   }
 
   @keyframes intro {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -258,7 +258,8 @@
         <div class="legal-links typo-text-small">
           <a href="https://v1.drips.network/" class="highlight">Back to Drips V1</a> •
           <a href="/legal/privacy">Privacy Policy</a> •
-          <a href="/legal/disclaimer">Disclaimer</a>
+          <a href="/legal/disclaimer">Disclaimer</a> •
+          <a href="/legal/access">Access</a>
         </div>
       </div>
       <div id="drips-sticker">

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -58,9 +58,13 @@
         <h1>Crowdfunding<span class="nudge">&nbsp;</span>for the Open Web</h1>
       </div>
       <div class="beta-notice">
-        Drips is currently in Beta, with Token Streaming features ready for you to try on testnets.
-        <a href="https://twitter.com/dripsnetwork">Follow us on Twitter</a> for updates on upcoming crowdfunding
-        functionality!
+        <p>
+          The new Drips is currently in Beta, with Token Streaming functionality ready for you to
+          try.
+          <a href="https://twitter.com/dripsnetwork">Follow us on Twitter</a> for updates on upcoming
+          crowdfunding functionality.
+        </p>
+        <a href="https://v1.drips.network/">Back to Drips V1</a>
       </div>
     </section>
     <section id="main-features">
@@ -255,6 +259,7 @@
         <p class="text-foreground-level-5">Supported by</p>
         <RadicleLogo />
         <div class="legal-links typo-text-small">
+          <a href="https://v1.drips.network/" class="highlight">Back to Drips V1</a> •
           <a href="/legal/privacy">Privacy Policy</a> •
           <a href="/legal/disclaimer">Disclaimer</a>
         </div>
@@ -381,11 +386,14 @@
     background-color: var(--color-caution-level-1);
     color: var(--color-caution-level-6);
     padding: 0.5rem 1.5rem;
-    border-radius: 2rem 0 2rem 2rem;
+    border-radius: 1rem 0 1rem 1rem;
     border: 1px solid var(--color-caution-level-6);
     max-width: 43rem;
-    text-align: left;
     margin-top: 3rem;
+
+    display: flex;
+    gap: 1rem;
+    flex-direction: column;
   }
 
   #hero .beta-notice a {
@@ -553,6 +561,10 @@
     text-decoration: underline;
   }
 
+  .legal-links a.highlight {
+    font-weight: bold;
+  }
+
   @media (max-width: 768px) {
     .grid {
       grid-template-columns: 1fr 1fr;
@@ -623,7 +635,7 @@
     #drips-sticker {
       height: 12rem;
       width: 12rem;
-      top: 8rem;
+      top: 9rem;
       left: 50%;
       transform: translateX(-50%);
     }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -254,6 +254,10 @@
       <div class="flex flex-col gap-4 items-center">
         <p class="text-foreground-level-5">Supported by</p>
         <RadicleLogo />
+        <div class="legal-links typo-text-small">
+          <a href="/legal/privacy">Privacy Policy</a> •
+          <a href="/legal/disclaimer">Disclaimer</a>
+        </div>
       </div>
       <div id="drips-sticker">
         <div class="illustration">
@@ -538,6 +542,15 @@
 
   #drips-sticker > .illustration {
     animation: rotate 20s linear infinite;
+  }
+
+  .legal-links {
+    margin-top: 1rem;
+    color: var(--color-foreground-level-5);
+  }
+
+  .legal-links a {
+    text-decoration: underline;
   }
 
   @media (max-width: 768px) {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -57,12 +57,8 @@
         <h1>Crowdfunding<span class="nudge">&nbsp;</span>for the Open Web</h1>
       </div>
       <div class="beta-notice">
-        <p>
-          The new Drips is currently in Beta, with Token Streaming functionality ready for you to
-          try.
-          <a href="https://twitter.com/dripsnetwork">Follow us on Twitter</a> for updates on upcoming
-          crowdfunding functionality.
-        </p>
+        The new Drips is currently in Beta, with Token Streaming functionality ready for you to try.
+        <a href="https://twitter.com/dripsnetwork">Follow us on Twitter</a> for updates.
         <a href="https://v1.drips.network/">Back to Drips V1</a>
       </div>
     </section>
@@ -382,14 +378,10 @@
     background-color: var(--color-caution-level-1);
     color: var(--color-caution-level-6);
     padding: 0.5rem 1.5rem;
-    border-radius: 1rem 0 1rem 1rem;
+    border-radius: 2rem 0 2rem 2rem;
     border: 1px solid var(--color-caution-level-6);
-    max-width: 43rem;
+    max-width: 44rem;
     margin-top: 3rem;
-
-    display: flex;
-    gap: 1rem;
-    flex-direction: column;
   }
 
   #hero .beta-notice a {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -12,7 +12,6 @@
   import MockDashboard from './components/mock-dashboard/mock-dashboard.svelte';
   import Button from '$lib/components/button/button.svelte';
   import LpSectionHeader from './components/lp-section-header.svelte';
-  import RadicleLogo from '../lib/components/illustrations/radicle-logo.svelte';
   import DripsSticker from '../lib/components/illustrations/drips-sticker.svelte';
   import BigDripsLogo from '$lib/components/illustrations/big-drips-logo.svelte';
   import ComingSoonBadge from './components/coming-soon-badge.svelte';
@@ -256,8 +255,6 @@
     </section>
     <section class="mt-8 mb-64">
       <div class="flex flex-col gap-4 items-center">
-        <p class="text-foreground-level-5">Supported by</p>
-        <RadicleLogo />
         <div class="legal-links typo-text-small">
           <a href="https://v1.drips.network/" class="highlight">Back to Drips V1</a> •
           <a href="/legal/privacy">Privacy Policy</a> •

--- a/src/routes/components/lp-header.svelte
+++ b/src/routes/components/lp-header.svelte
@@ -20,11 +20,13 @@
     <div class="beta-notice" class:offset={showLogo}><BetaBadge /></div>
   </div>
   <nav>
-    <a href="https://github.com/radicle-dev" target="_blank" rel="noreferrer"
+    <a href="https://github.com/radicle-dev?q=drips" target="_blank" rel="noreferrer"
       ><Button variant="ghost">Code</Button></a
     >
-    <a href="https://v2.docs.drips.network/docs/whats-a-drip.html" target="_blank" rel="noreferrer"
-      ><Button variant="ghost">Docs</Button></a
+    <a
+      href="https://v2.docs.drips.network/docs/the-drips-app/getting-started"
+      target="_blank"
+      rel="noreferrer"><Button variant="ghost">Docs</Button></a
     >
     <a class="cta" href="/app"><Button variant="primary">Open app</Button></a>
   </nav>

--- a/src/routes/components/lp-header.svelte
+++ b/src/routes/components/lp-header.svelte
@@ -23,10 +23,8 @@
     <a href="https://github.com/radicle-dev?q=drips" target="_blank" rel="noreferrer"
       ><Button variant="ghost">Code</Button></a
     >
-    <a
-      href="https://v2.docs.drips.network/docs/the-drips-app/getting-started"
-      target="_blank"
-      rel="noreferrer"><Button variant="ghost">Docs</Button></a
+    <a href="https://v2.docs.drips.network/docs/whats-a-drip.html" target="_blank" rel="noreferrer"
+      ><Button variant="ghost">Docs</Button></a
     >
     <a class="cta" href="/app"><Button variant="primary">Open app</Button></a>
   </nav>

--- a/src/routes/components/lp-header.svelte
+++ b/src/routes/components/lp-header.svelte
@@ -85,6 +85,7 @@
     transform: translateX(-40px);
     transition: transform 0.3s;
     user-select: none;
+    color: var(--color-caution-level-6);
   }
 
   .beta-notice.logoOffset {

--- a/src/routes/components/lp-header.svelte
+++ b/src/routes/components/lp-header.svelte
@@ -39,6 +39,8 @@
     align-items: center;
     border: 1px solid var(--color-foreground);
     padding: 1rem;
+    left: 50%;
+    transform: translateX(-50%);
     border-radius: 2.5rem 0 2.5rem 2.5rem;
     position: fixed;
     width: calc(78rem - 3px);

--- a/src/routes/components/lp-header.svelte
+++ b/src/routes/components/lp-header.svelte
@@ -9,12 +9,12 @@
 </script>
 
 <header class:raised={scrolledDown}>
-  <div class="logo">
+  <a class="logo" href="/">
     <div class="inner" class:logoOffset={showLogo}>
       <ThreeDrips />
       <DripsLogo />
     </div>
-  </div>
+  </a>
   <nav>
     <a href="https://github.com/radicle-dev" target="_blank" rel="noreferrer"
       ><Button variant="ghost">Code</Button></a
@@ -32,8 +32,8 @@
     justify-content: space-between;
     align-items: center;
     border: 1px solid var(--color-foreground);
-    padding: var(--spacing-s);
-    border-radius: var(--border-radius-pointy);
+    padding: 1rem;
+    border-radius: 2rem 0 2rem 2rem;
     position: fixed;
     width: calc(78rem - 3px);
     max-width: calc(100vw - 2rem);
@@ -49,7 +49,7 @@
   }
 
   .logo {
-    margin-left: var(--spacing-xs);
+    margin-left: 0.5rem;
     height: 28px;
   }
 

--- a/src/routes/components/lp-header.svelte
+++ b/src/routes/components/lp-header.svelte
@@ -9,12 +9,15 @@
 </script>
 
 <header class:raised={scrolledDown}>
-  <a class="logo" href="/">
-    <div class="inner" class:logoOffset={showLogo}>
-      <ThreeDrips />
-      <DripsLogo />
-    </div>
-  </a>
+  <div class="left">
+    <a class="logo" href="/">
+      <div class="inner" class:logoOffset={showLogo}>
+        <ThreeDrips />
+        <DripsLogo />
+      </div>
+    </a>
+    <h5 class="beta-notice" class:logoOffset={showLogo}>Beta</h5>
+  </div>
   <nav>
     <a href="https://github.com/radicle-dev" target="_blank" rel="noreferrer"
       ><Button variant="ghost">Code</Button></a
@@ -48,6 +51,11 @@
     box-shadow: var(--elevation-medium);
   }
 
+  .left {
+    display: flex;
+    gap: 0.75rem;
+  }
+
   .logo {
     margin-left: 0.5rem;
     height: 28px;
@@ -65,6 +73,22 @@
     display: flex;
     flex-direction: column;
     gap: 28px;
+  }
+
+  .beta-notice {
+    background-color: var(--color-caution-level-2);
+    padding: 0.125rem 0.625rem 0.125rem 0.75rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 2rem 0 2rem 2rem;
+    transform: translateX(-40px);
+    transition: transform 0.3s;
+    user-select: none;
+  }
+
+  .beta-notice.logoOffset {
+    transform: translateX(0);
   }
 
   nav {
@@ -91,6 +115,10 @@
 
     nav {
       gap: 0;
+    }
+
+    .beta-notice {
+      display: none;
     }
   }
 </style>

--- a/src/routes/components/lp-header.svelte
+++ b/src/routes/components/lp-header.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import BetaBadge from '$lib/components/beta-badge/beta-badge.svelte';
   import Button from '$lib/components/button/button.svelte';
   import DripsLogo from '$lib/components/illustrations/logo.svelte';
   import ThreeDrips from '$lib/components/illustrations/three-drips.svelte';
@@ -16,7 +17,7 @@
         <DripsLogo />
       </div>
     </a>
-    <h5 class="beta-notice" class:logoOffset={showLogo}>Beta</h5>
+    <div class="beta-notice" class:offset={showLogo}><BetaBadge /></div>
   </div>
   <nav>
     <a href="https://github.com/radicle-dev" target="_blank" rel="noreferrer"
@@ -36,7 +37,7 @@
     align-items: center;
     border: 1px solid var(--color-foreground);
     padding: 1rem;
-    border-radius: 2rem 0 2rem 2rem;
+    border-radius: 2.5rem 0 2.5rem 2.5rem;
     position: fixed;
     width: calc(78rem - 3px);
     max-width: calc(100vw - 2rem);
@@ -76,19 +77,11 @@
   }
 
   .beta-notice {
-    background-color: var(--color-caution-level-2);
-    padding: 0.125rem 0.625rem 0.125rem 0.75rem;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    border-radius: 2rem 0 2rem 2rem;
     transform: translateX(-40px);
     transition: transform 0.3s;
-    user-select: none;
-    color: var(--color-caution-level-6);
   }
 
-  .beta-notice.logoOffset {
+  .beta-notice.offset {
     transform: translateX(0);
   }
 

--- a/src/routes/legal/+layout.svelte
+++ b/src/routes/legal/+layout.svelte
@@ -1,0 +1,29 @@
+<script>
+  import LpHeader from '../components/lp-header.svelte';
+</script>
+
+<div class="wrapper">
+  <LpHeader />
+  <div class="content">
+    <slot />
+  </div>
+</div>
+
+<style>
+  .wrapper {
+    max-width: 80rem;
+    width: 100vw;
+    margin: 0 auto;
+    padding: 1rem;
+    padding-top: 6rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .content {
+    width: 44rem;
+    padding-top: 2rem;
+    padding-left: 1rem;
+  }
+</style>

--- a/src/routes/legal/+layout.svelte
+++ b/src/routes/legal/+layout.svelte
@@ -1,4 +1,5 @@
 <script>
+  import './longform-text.css';
   import LpHeader from '../components/lp-header.svelte';
 </script>
 

--- a/src/routes/legal/+layout.svelte
+++ b/src/routes/legal/+layout.svelte
@@ -22,7 +22,7 @@
   }
 
   .content {
-    width: 44rem;
+    max-width: 44rem;
     padding-top: 2rem;
     padding-left: 1rem;
   }

--- a/src/routes/legal/+layout.svelte
+++ b/src/routes/legal/+layout.svelte
@@ -3,7 +3,7 @@
   import LpHeader from '../components/lp-header.svelte';
 </script>
 
-<div class="wrapper">
+<div class="wrapper legal-page">
   <LpHeader />
   <div class="content">
     <slot />

--- a/src/routes/legal/access/+page.svelte
+++ b/src/routes/legal/access/+page.svelte
@@ -1,0 +1,67 @@
+<svelte:head>
+  <title>Drips • Access</title>
+  <meta
+    name="description"
+    content="Drips is a Web3 toolkit that enables developers to raise and manage funds by the second, without any platform fees."
+  />
+</svelte:head>
+
+<h1>Access</h1>
+<p class="typo-text-small">Last edited: 07 March 2023</p>
+
+<p>
+  The Drips protocol is a collection of public, open smart contracts deployed on EVM-based
+  blockchains, equally accessible to every user and application. Because of this, there is no one
+  single way of interacting with the Drips protocol. While the Drips App is one way of interacting
+  with the Drips protocol, users can also access the full power and functionality of Drips contracts
+  in any of the following alternative ways as well:
+</p>
+<p>
+  The <a
+    href="https://github.com/radicle-dev/drips-js-sdk"
+    target="_blank"
+    rel="noopener noreferrer">Drips SDK</a
+  > is a Javascript SDK that allows any application or user-created code to interact directly with the
+  Drips smart contracts and utilize the full feature set of the protocol in whatever way they wish. Drips
+  contracts can be freely integrated into any website, dapp or application at any time using the SDK.
+</p>
+<p>
+  <a href="https://etherscan.io" target="_blank" rel="noopener noreferrer">Etherscan</a> is a block
+  explorer and analytics platform for Ethereum. Other networks have similar block exploers, often
+  also operated by Etherscan. The Drips contracts can be accessed using these block explorers at the
+  addresses specified on the
+  <a
+    href="https://docs.drips.network/docs/for-developers/smart-contract-and-subgraph-details"
+    target="_blank"
+    rel="noopener noreferrer">Smart Contract and Subgraph Details Page</a
+  >. For example, the DripsHub smart contract on the Rinkeby testnet can be acessed
+  <a
+    href="https://rinkeby.etherscan.io/address/0xfbcD6918907902c106A99058146CBdBb76a812f6"
+    target="_blank"
+    rel="noopener noreferrer">here</a
+  >.
+</p>
+<p>
+  <a href="https://eth.build/" target="_blank" rel="noopener noreferrer">ethBuild</a> is an educational
+  sandbox for web3, including drag-and-drop programming and open source building blocks. With ethBuild,
+  you can call a function on an Ethereum contract (for example, to create a Drip or Split configuration)
+  by sending it a transaction with the function arguments in the data.
+</p>
+<p>
+  <a href="https://www.myetherwallet.com/" target="_blank" rel="noopener noreferrer"
+    >MyEtherWallet</a
+  > is a free, client side interface helping you interact with the Ethereum blockchain. Their easy-to-use,
+  open-source platform allows you to generate wallets, interact with (Drips) smart contracts, and more.
+</p>
+<p>
+  The <a href="https://web3js.readthedocs.io/en/v1.7.5/" target="_blank" rel="noopener noreferrer"
+    >web3.js Library</a
+  > makes it easy to interact with smart contracts on the Ethereum blockchain, including the Drips smart
+  contracts.
+</p>
+<p>
+  The <a href="https://docs.ethers.io/v5/" target="_blank" rel="noopener noreferrer"
+    >ethers.js Library</a
+  > is another Javascript library for interacting directly with Ethereum smart contracts, including the
+  Drips smart contracts.
+</p>

--- a/src/routes/legal/disclaimer/+page.svelte
+++ b/src/routes/legal/disclaimer/+page.svelte
@@ -1,3 +1,11 @@
+<svelte:head>
+  <title>Drips • Disclaimer</title>
+  <meta
+    name="description"
+    content="Drips is a Web3 toolkit that enables developers to raise and manage funds by the second, without any platform fees."
+  />
+</svelte:head>
+
 <h1>Disclaimer</h1>
 <p>Content goes here</p>
 

--- a/src/routes/legal/disclaimer/+page.svelte
+++ b/src/routes/legal/disclaimer/+page.svelte
@@ -1,0 +1,12 @@
+<h1>Disclaimer</h1>
+<p>Content goes here</p>
+
+<style>
+  h1 {
+    margin-bottom: 2rem;
+  }
+
+  p {
+    margin-bottom: 1rem;
+  }
+</style>

--- a/src/routes/legal/disclaimer/+page.svelte
+++ b/src/routes/legal/disclaimer/+page.svelte
@@ -7,7 +7,286 @@
 </svelte:head>
 
 <h1>Disclaimer</h1>
-<p>Content goes here</p>
+<p class="typo-text-small">Last edited: 07 March 2023</p>
+<p>
+  This is a disclaimer for the Radicle Network (the “Disclaimer”).Please read it carefully. The
+  Radicle Network consists of the Radicle Technology Stack (including in particular, the Drips
+  Protocol, the Radicle-Link P2P Protocol and the Radicle Client Interface) as well as any other
+  Radicle technology, services and/or Content (as defined below).
+</p>
+<p>
+  BY ACCESSING THE RADICLE NETWORK, YOU ACKNOWLEDGE AND AGREE THAT YOUR USE OF THE RADICLE NETWORK
+  IS ENTIRELY AT YOUR OWN RISK. The Radicle Network is available for use to the public on an “as-is”
+  basis, and no representations or warranties of any kind are made with respect to the Radicle
+  Network, its operations and functionality, or its fitness for any specific purpose.
+</p>
+<p>
+  This website is maintained on a voluntary basis by the Radicle Foundation (the “Foundation”). The
+  Foundation is a Swiss foundation whose purpose is to support the development of resilient and
+  humane software infrastructures.The Foundation is committed to supporting projects and people that
+  develop non-extractive peer-to-peer technologies that promote internet freedom, including, among
+  others, the Radicle Network. While the Foundation previously assisted in the development and
+  deployment of the Radicle Network, which includes the Drips Protocol, the Foundation does not own,
+  manage, or control or act as an administrator of the Radicle Network. The Radicle Network
+  presently operates in a fully decentralized and autonomous manner, and the Drips Protocol offers
+  Users an opt-in Ethereum protocol integration. The Foundation is neither involved in nor in any
+  way responsible for the ongoing operation, running, or functioning of the Radicle Network and/or
+  any of the interactions, collaborations or contractual relationships between Users on the Radicle
+  Network.
+</p>
+<p>
+  The Foundation has voluntarily posted this Disclaimer for the benefit of the community of users of
+  the Radicle Network. By accessing the Radicle Network, You acknowledge and agree that under no
+  circumstances shall the Foundation be liable to You for any losses or damages (including any
+  general, special, incidental or consequential damages) arising out of your use, or your inability
+  to use the Radicle Network or the Software (as defined below).
+</p>
+<p>
+  This Disclaimer may be updated and modified from time to time. The Disclaimer as so updated and
+  modified are deemed effective as of the date they are published on <a
+    href="https://radicle.xyz/disclaimer">radicle.xyz</a
+  >
+  and <a href="https://app.drips.network/disclaimer">drips.network</a>. It is the User’s
+  responsibility to periodically check for the most recent version of the Disclaimer.
+</p>
+<h2>Introduction</h2>
+<p>
+  This Disclaimer governs access to and use of the Radicle Network. The Radicle Network enables
+  Users to manage software projects and to host, develop, and review software code in a
+  collaborative manner.
+</p>
+<p>
+  The Radicle Network is a fully decentralized and autonomous ecosystem with an opt-in Ethereum
+  protocol integration, offered by the Drips Protocol. There is no single third party solely
+  involved in or in any way responsible for the operation, running or functioning of the Radicle
+  Network and/or any of the interactions, collaborations or (contractual) relationships among Users
+  on the Radicle Network.
+</p>
+<p>
+  The underlying software protocols of the Radicle Network (the “Software”) have been developed and
+  published under the GPLv3 license, which forms an integral part of this Disclaimer. The full
+  license strategy of Radicle Network can be viewed here:
+  https://radicle.community/t/radicle-licensing-model/282.
+</p>
+<p>
+  As the Radicle Network (and in particular, the Software) is of experimental nature, You
+  acknowledge that the Radicle Network is likely to contain bugs, defects, or errors (including any
+  bug, defect, or error relating to or resulting from the display, manipulation, processing,
+  storage, transmission, or use of data) that may materially and adversely affects the use,
+  functionality, or performance of the Radicle Network or any product or system containing or used
+  in conjunction with the Radicle Network.
+</p>
+<p>
+  Part of the Radicle Network’s feature set is a dedicated Ethereum-based transaction system (the
+  Drips Protocol), which enables Users to transfer DAI / ETH and/or the Radicle Network’s native
+  tokens (“Radicle Tokens”) via the Radicle Network to realize some core functionalities of the
+  Radicle Network. Transfers of DAI / ETH via Radicle Network require ETH as gas.
+</p>
+<p>
+  THE RADICLE NETWORK AND THE SOFTWARE ARE HIGHLY EXPERIMENTAL AND ANY REAL ETH, DAI, OR RAD SENT TO
+  POTENTIALLY INSECURE SOFTWARE THAT REMAINS UNDER DEVELOPMENT ARE AT RISK OF BEING LOST
+  INDEFINITELY, WITHOUT ANY KIND OF CONSIDERATION.
+</p>
+<h2>Content / Loss of Content</h2>
+<p>
+  You acknowledge and understand that there is no centralized entity responsible for any
+  information, developments, software, code or other data and any corresponding rights (hereinafter
+  "Content") developed, exchanged, shared, stored, made available on or via the Radicle Network. You
+  acknowledge and accept that there is no party making any representations or warranties with
+  respect to any such Content and no party has assumed any liability as to such Content.
+</p>
+<p>
+  You are aware and acknowledge that your processing, development, exchange, storage sharing,
+  provision of, contribution to or other involvement in Content on or via the Radicle Network takes
+  place in an experimental environment. You acknowledge and agree that You have no claim as to the
+  integrity and consistency of any Content. You further acknowledge and agree that there is a risk
+  of total and irretrievable loss of Content and that You are solely responsible for secure storage
+  (e.g. backup copies) of Content and that no other party shall be responsible and liable under any
+  circumstance for any loss or corruption of Content.
+</p>
+<h2>Contacts and (Contractual) Relationships Among Users</h2>
+<p>
+  Users enter into contractual and other relationships with other Users and third-party developers
+  supporting the Radicle Network at their own risk. There is no centralized entity or party that is
+  liable for any damages that may arise from any breaches under any such contracts or relationships.
+  (See section “Content / Loss of Content”.)
+</p>
+<h2>No Involvement in Funding Functions and Project Tokens</h2>
+<p>
+  No third party, including, without limitation, the Foundation is involved in the issuance,
+  transfer, custody, and management of any funds raised by any Users as part of such User’s funding
+  events including the creation and issuance of tokens by or for such User (“Project Tokens”).You
+  understand and acknowledge that the Foundation has neither access to nor any other possibility to
+  control and/or influence any corresponding transactions or funds in connection with any Project
+  Token which may be issued by Users using the Funding Functions of the Radicle Network, including
+  Drips Protocol.The User solely bears any and all liability in connection with its Project Tokens
+  as well as the use of the Funding Functions of the Radicle Network, including Drips Protocol.
+</p>
+<h2>Services and Availability</h2>
+<p>
+  The User acknowledges and agrees that there is no third party that has any obligation to provide,
+  operate, support, maintain, or further develop the Radicle Network and/or the Software.The
+  Foundation plays no such role and has no such responsibility. Accordingly, Users access and use
+  the Radicle Network and the Software at their own risk and solely bear any and all risk of loss in
+  connection therewith (in particular, but without limitation, as set forth in section “Content /
+  Loss of Content”).
+</p>
+<p>
+  The User acknowledges that there is no third party providing any warranties related to the
+  availability or functionality of the Radicle Network or the Software.As a result, the Radicle
+  Network could cease functioning at any time or the Radicle Network, including the Software could
+  malfunction or fail to perform or operate as contemplated by or intended by the User and that the
+  User is solely responsible for any damages or losses suffered by it as a result.
+</p>
+<h2>Disclaimer of Warranty</h2>
+<p>
+  THERE IS NO WARRANTY, EXPRESS OR IMPLIED, FOR THE RADICLE NETWORK AND/OR THE SOFTWARE AND/OR
+  CONTENT. USERS ACKNOWLEDGE AND AGREE THAT THEY ACCESS AND USE THE RADICLE NETWORK, SOFTWARE AND
+  CONTENT AS IS, WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+  ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE RADICLE NETWORK AND THE SOFTWARE IS WITH THE
+  USER. SHOULD THE RADICLE NETWORK OR SOFTWARE PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY
+  SERVICING, REPAIR OR CORRECTION.
+</p>
+<h2>Limitation of Liability</h2>
+<p>
+  YOU UNDERSTAND THAT YOU USE THE RADICLE NETWORK AND THE SOFTWARE AT YOUR OWN RISK.UNLESS YOU AND
+  ANOTHER USER OR YOU AND A THIRD-PARTY DEVELOPER OTHERWISE AGREE IN WRITING, YOU ARE SOLELY
+  RESPONSIBLE FOR ANY DAMAGES OR LOSSES YOU MAY INCUR, INCLUDING ANY SPECIAL, INCIDENTAL OR
+  CONSEQUENTIAL DAMAGES ARISING OUT OF YOUR USE, OR INABILITY TO USE, THE RADICLE NETWORK OR THE
+  SOFTWARE (INCLUDING BUT NOT LIMITED TO LOSS OF DATA, BUSINESS INTERRUPTION, DATA BEING RENDERED
+  INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE SOFTWARE TO OPERATE
+  WITH ANY OTHER SOFTWARE OR THE NON-PAYMENT OF A FEE).
+</p>
+<h2>Assumption of Risks of Cryptographic Tokens, Currencies and Systems</h2>
+<p>
+  There are risks associated with purchasing, owning and using Radicle Tokens.In order to access and
+  make use of parts of and certain features within the Radicle Network, you may need Radicle Tokens,
+  ETH, DAI, Project Tokens or other smart contract-based tokens (collectively, “Cryptographic
+  Tokens”). These features include the creation of globally unique individual and group identities
+  as well as voting capabilities in order to participate in the decentralized governance system of
+  Radicle Network or the Radicle Network’s funding features.
+</p>
+<p>
+  By accessing and making use of such features and/or by using the Radicle Network in any way, You
+  acknowledge the inherent risks associated with cryptographic systems; and warrant that you have an
+  understanding of the usage and intricacies of Cryptographic Tokens.
+</p>
+<p>
+  You understand that Ethereum and other blockchain technologies and associated Cryptographic Tokens
+  are highly volatile due to many factors including but not limited to adoption, speculation,
+  technology, and security risks. You also acknowledge that the cost of transacting using such
+  technologies is variable and may increase at any time causing impact to any activities taking
+  place on the Ethereum blockchain.
+</p>
+<p>
+  You acknowledge that you are solely responsible for transacting and holding Cryptographic Tokens
+  that you may choose to use while accessing and/or interacting with the Radicle Network as well as
+  for any losses or damages resulting from the use of Cryptographic Token.
+</p>
+<p>
+  Cryptographic Tokens do not represent or constitute any ownership rights or stake, shares or
+  security or equivalent rights nor any rights to receive future revenues or shares or any other
+  form of participation in or relating to the Radicle Network. In particular, you understand and
+  accept that Cryptographic Tokens do not represent or confer any ownership right or stake, share,
+  security, or equivalent rights, or any right to receive future revenue shares, intellectual
+  property rights or any other form of participation in or relating to the Radicle Network.
+</p>
+<p>
+  You are responsible for implementing reasonable measures for securing the wallet, vault or other
+  storage mechanism you use to receive and hold Cryptographic Tokens purchased, including any
+  requisite private key(s) or other credentials necessary to access such storage mechanism(s). If
+  your private key(s) or other access credentials are lost, you may lose access to your
+  Cryptographic Tokens and You are solely responsible for any losses, costs, or expenses relating to
+  lost access credentials or an incompatible wallet.
+</p>
+<p>
+  The Radicle Network is not designed to transact with and/or issue Cryptographic Tokens that are
+  structured or sold as securities or any other form of investment product. You are solely
+  responsible for any direct or consequential loss or damage of any kind whatsoever arising directly
+  or indirectly from a misuse of the Radicle Network by You or related to information provided or
+  distributed by You through the Radicle Network.
+</p>
+<p>
+  By purchasing, owning, and using Cryptographic Tokens, You expressly acknowledge and assume the
+  risks concerning losing access to such Cryptographic Tokens due to loss of private key(s),
+  custodial error, or purchaser error and risks related with the Software; risk of mining attacks;
+  risk of hacking and security weaknesses; risks associated with markets for tokens; risk of
+  uninsured losses; risks associated with uncertain regulations and enforcement actions; risks
+  arising from taxation; risk of competing platforms; risk of insufficient interest in the Radicle
+  Network or distributed applications; risks associated with the development and maintenance of the
+  Radicle Network risk of dissolution of the Radicle Network; risks arising from lack of governance
+  rights and unanticipated risks.
+</p>
+<h2>Compliance with Laws</h2>
+<p>
+  The Radicle Network could be impacted by one or more regulatory inquiries or regulatory action,
+  which could impede or limit your ability to access or use the Radicle Network. You acknowledge and
+  agree that You are solely responsible for complying with such laws and regulations applicable to
+  you and your use of Cryptographic Tokens, the Radicle Network, and the Software.
+</p>
+<h2>Account Password / Security</h2>
+<p>
+  When setting up an identity within the Radicle Network, it lies within the responsibility of the
+  User to keep its own account secrets, including any passwords. It is recommended that You (a)
+  never use the same password for the Radicle Network that you use or have ever used in any other
+  context; (b) keep your secret information and password confidential and do not share them with
+  anyone else. There is no possibility for You to recover your private password.
+</p>
+<h2>Services Provided by Third Parties</h2>
+<p>
+  Some functions of the Radicle Network rely on the proper operation of the Ethereum Protocol and/or
+  other third-party infrastructure or services. Use of and accessing the Radicle Network does not
+  give rise to any representations or warranties of any kind regarding any site, service, or
+  resource provided by a third party, including, without limitation, any representations or
+  warranties regarding the accuracy, completeness, usefulness, security, or legitimacy of the
+  Radicle Network. The Radicle Network does not control the Ethereum Protocol or any third-party
+  sites, services, and resources.Therefore, you are solely responsible for any harm, loss, or damage
+  that may arise from the Ethereum Protocol or any third-party sites, services, and resources. If
+  You decide to access the Radicle Network, you are aware that you do so entirely at your own risk
+  and subject to the terms and conditions for such third-party services, infrastructures, sites or
+  resources.
+</p>
+<h2>Rules of Conduct</h2>
+<p>Users of shall refrain from:</p>
+<p />
+I. ILLICIT CONTENT: Collaborating to, posting, requesting, transmitting, rendering or otherwise making
+available or creating through or in connection with the use of the Radicle Network and/or the Software
+any Content or other materials that are or may be: (a) illegal/non-compliant and or threatening, harassing,
+degrading, hateful or intimidating, or otherwise fail to respect the rights and dignity of others; (b)
+defamatory, libelous, fraudulent or otherwise tortious; (c) obscene, indecent, pornographic or otherwise
+objectionable; or (d) protected by copyright, trademark, trade secret, right of publicity or privacy
+or any other proprietary right, without the express prior written consent of the applicable owner.<br
+/>II. VIRUSES: Posting, transmitting or otherwise making available through or in connection with the
+use of the Radicle Network and/or the Software any virus, worm, Trojan horse, Easter egg, time bomb,
+spyware, scareware, malware or other computer code, file or program that is or is potentially
+harmful or invasive or intended to damage or hijack the operation of, or to monitor the use of, any
+hardware, software or equipment.<br />III. UNLAWFUL ACTIVITIES: Using the Radicle Network and/or the
+Software for any purpose that is fraudulent or otherwise tortious or unlawful, including but not
+limited to illegal gambling, money laundering, fraud, blackmail, extortion, ransoming data or the
+financing of terrorism, intellectual property infringement, or violent or abusive activities.
+<h2>Personal Data</h2>
+<p>
+  The User acknowledges that by using the Radicle Network (including Content) and/or contributing
+  Content to the Radicle Network certain personal information (“Personal Information”, as further
+  described under “Data in P2P and Blockchain Infrastructures” in the <router-link to="/privacy"
+    >Privacy Policy</router-link
+  >) may be shared with the other Users of the Radicle Network. Since the Personal Information used
+  to interact with the Radicle Network (which is listed in the Privacy Policy) is not collected by
+  the Foundation but rather shared directly between the Users, the Foundation does not qualify as a
+  data controller or data processor according to the GDPR. Users understand that the Foundation has
+  no control over Personal Information provided to other Users of the Radicle Network and agree to
+  not hold the Foundation liable for any misuse of Personal Information by other Users of the
+  Radicle Network. The Users further understand that the Personal Information is not recorded,
+  stored or otherwise processed by the Foundation. Consequently, the rights of the Users relating to
+  their Personal Information as provided in the GDPR cannot be asserted against the Foundation.
+</p>
+<h2>Governing Law</h2>
+<p>
+  This Disclaimer shall be construed and interpreted in accordance with the substantive laws of
+  Switzerland, excluding the Swiss conflict of law rules. The United Nations Convention for the
+  International Sales of Goods is excluded.
+</p>
 
 <style>
   h1 {

--- a/src/routes/legal/longform-text.css
+++ b/src/routes/legal/longform-text.css
@@ -1,0 +1,27 @@
+h1 {
+  margin-bottom: 2rem;
+}
+
+h2,
+h3 {
+  margin-top: 2rem;
+  margin-bottom: 1.5rem;
+}
+
+h4 {
+  margin-bottom: 1rem;
+}
+
+p,
+ol {
+  margin-bottom: 1rem;
+}
+
+ol li {
+  list-style: initial;
+  margin-left: 1rem;
+}
+
+a {
+  text-decoration: underline;
+}

--- a/src/routes/legal/longform-text.css
+++ b/src/routes/legal/longform-text.css
@@ -1,27 +1,27 @@
-h1 {
+.legal-page h1 {
   margin-bottom: 2rem;
 }
 
-h2,
-h3 {
+.legal-page h2,
+.legal-page h3 {
   margin-top: 2rem;
   margin-bottom: 1.5rem;
 }
 
-h4 {
+.legal-page h4 {
   margin-bottom: 1rem;
 }
 
-p,
-ol {
+.legal-page p,
+.legal-page ol {
   margin-bottom: 1rem;
 }
 
-ol li {
+.legal-page ol li {
   list-style: initial;
   margin-left: 1rem;
 }
 
-a {
+.legal-page a {
   text-decoration: underline;
 }

--- a/src/routes/legal/privacy/+page.svelte
+++ b/src/routes/legal/privacy/+page.svelte
@@ -1,3 +1,11 @@
+<svelte:head>
+  <title>Drips • Data & Privacy Policy</title>
+  <meta
+    name="description"
+    content="Drips is a Web3 toolkit that enables developers to raise and manage funds by the second, without any platform fees."
+  />
+</svelte:head>
+
 <h1>Data & Privacy Policy</h1>
 
 <p>Last edited: 21 October 2022</p>

--- a/src/routes/legal/privacy/+page.svelte
+++ b/src/routes/legal/privacy/+page.svelte
@@ -1,0 +1,42 @@
+<h1>Data & Privacy Policy</h1>
+
+<p>Last edited: 21 October 2022</p>
+<p>
+  Radicle websites (including radicle.xyz) are maintained on a voluntary basis by the Radicle
+  Foundation (the “Foundation”). The Foundation is a Swiss foundation whose purpose is to support
+  the development of resilient and humane software infrastructures. The Foundation is committed to
+  supporting projects and people that develop non-extractive peer-to-peer technologies that promote
+  internet freedom, including, among others, the Radicle project. While the Foundation previously
+  assisted in the development and deployment of the Radicle Network, the Foundation does not own,
+  manage, or control or act as an administrator of the Radicle Network. The Radicle Network
+  presently operates in a fully decentralized and autonomous manner and has an opt-in Ethereum
+  protocol integration. The Foundation is neither involved in nor in any way responsible for the
+  ongoing operation, running, or functioning of the Radicle Network and/or any of the interactions,
+  collaborations or contractual relationships between Users on the Radicle Network. The Foundation
+  voluntarily supports the growth and development of the Radicle project, including the Radicle
+  Network (further defined in the Disclaimer) as well as the Radicle websites and other
+  communication channels for the Radicle community (as described below). The Foundation has posted
+  this Privacy Policy for the benefit of the community of supporters of the Radicle project. The
+  Foundation takes Radicle community member's data and privacy seriously - and is committed to
+  protecting the rights of Radicle community members when it comes to their data and privacy. This
+  policy applies to all of the Foundation's data processing activities where it acts as a data
+  controller. In this policy, "Foundation" refers to Radicle Foundation, a foundation incorporated
+  in Switzerland with its registered address at Suurstoffi 37, 6343 Rotkreuz. For more information
+  about the Foundation, see the Imprint or the “Contact” section of this policy. The Foundation may
+  make changes to this policy every so often. When changed, the Foundation will change the “Last
+  edited” date at the top of the page. You are encouraged to review this policy regularly in order
+  to stay informed about the Foundation's information practices. If you do not agree to the revised
+  policy, do not use, access, or interact with the Radicle Network, the Radicle Technology Stack,
+  the Radicle websites, and any other Radicle communication outlet (and unsubscribe where
+  applicable).
+</p>
+
+<style>
+  h1 {
+    margin-bottom: 2rem;
+  }
+
+  p {
+    margin-bottom: 1rem;
+  }
+</style>

--- a/src/routes/legal/privacy/+page.svelte
+++ b/src/routes/legal/privacy/+page.svelte
@@ -8,9 +8,9 @@
 
 <h1>Data & Privacy Policy</h1>
 
-<p>Last edited: 21 October 2022</p>
+<p class="typo-text-small">Last edited: 07 March 2023</p>
 <p>
-  Radicle websites (including radicle.xyz) are maintained on a voluntary basis by the Radicle
+  Radicle websites (including *.drips.network) are maintained on a voluntary basis by the Radicle
   Foundation (the “Foundation”). The Foundation is a Swiss foundation whose purpose is to support
   the development of resilient and humane software infrastructures. The Foundation is committed to
   supporting projects and people that develop non-extractive peer-to-peer technologies that promote
@@ -20,23 +20,356 @@
   presently operates in a fully decentralized and autonomous manner and has an opt-in Ethereum
   protocol integration. The Foundation is neither involved in nor in any way responsible for the
   ongoing operation, running, or functioning of the Radicle Network and/or any of the interactions,
-  collaborations or contractual relationships between Users on the Radicle Network. The Foundation
-  voluntarily supports the growth and development of the Radicle project, including the Radicle
-  Network (further defined in the Disclaimer) as well as the Radicle websites and other
-  communication channels for the Radicle community (as described below). The Foundation has posted
-  this Privacy Policy for the benefit of the community of supporters of the Radicle project. The
-  Foundation takes Radicle community member's data and privacy seriously - and is committed to
-  protecting the rights of Radicle community members when it comes to their data and privacy. This
-  policy applies to all of the Foundation's data processing activities where it acts as a data
+  collaborations or contractual relationships between Users on the Radicle Network.
+</p>
+<p>
+  The Foundation voluntarily supports the growth and development of the Radicle project, including
+  the Radicle Network (further defined in the <router-link to="/disclaimer">Disclaimer</router-link
+  >) as well as the Radicle websites and other communication channels for the Radicle community (as
+  described below). The Foundation has posted this Privacy Policy for the benefit of the community
+  of supporters of the Radicle project. The Foundation takes Radicle community member’s data and
+  privacy seriously - and is committed to protecting the rights of Radicle community members when it
+  comes to their data and privacy.
+</p>
+<p>
+  This policy applies to all of the Foundation’s data processing activities where it acts as a data
   controller. In this policy, "Foundation" refers to Radicle Foundation, a foundation incorporated
   in Switzerland with its registered address at Suurstoffi 37, 6343 Rotkreuz. For more information
-  about the Foundation, see the Imprint or the “Contact” section of this policy. The Foundation may
-  make changes to this policy every so often. When changed, the Foundation will change the “Last
-  edited” date at the top of the page. You are encouraged to review this policy regularly in order
-  to stay informed about the Foundation's information practices. If you do not agree to the revised
-  policy, do not use, access, or interact with the Radicle Network, the Radicle Technology Stack,
-  the Radicle websites, and any other Radicle communication outlet (and unsubscribe where
-  applicable).
+  about the Foundation, see the Imprint or the “Contact” section of this policy.
+</p>
+<p>
+  The Foundation may make changes to this policy every so often. When changed, the Foundation will
+  change the “Last edited” date at the top of the page. You are encouraged to review this policy
+  regularly in order to stay informed about the Foundation’s information practices. If you do not
+  agree to the revised policy, do not use, access, or interact with the Radicle Network, the Radicle
+  Technology Stack, the Radicle websites, and any other Radicle communication outlet (and
+  unsubscribe where applicable).
+</p>
+<h2>Data in P2P and Blockchain Infrastructures</h2>
+<p>
+  While you could use Radicle software to privately edit your own code on your computer, without
+  sharing to the Radicle Network, all code that you publish to the Radicle Network is to be
+  considered public. Because any contribution on the Radicle Network is linked to a public key, all
+  contributions can be verified as coming from a public key. If your public key is linked to
+  personally identifiable information, like your git username or email, this information will also
+  be publicly accessible.
+</p>
+<p>
+  Data is disseminated through the Radicle Network via a process called gossip. That is,
+  participants in the Radicle Network share and spread data they are "interested" in by keeping
+  redundant copies locally and sharing deltas with peers. In the Radicle Network, data is replicated
+  across connected code repositories according to a “social graph” of contributors and maintainers,
+  enabling source code and changesets to be disseminated according to use and value: the more peers
+  who are interested in a certain project, the more available this project is made to the Radicle
+  Network.
+</p>
+<p>
+  It’s important to understand that any information you publish onto the Radicle Network is <b
+    >public by design</b
+  >. Because of the way gossip works, once you contribute to code on or share a repository with the
+  Radicle Network, any information that is held in git (potentially your name, email, or public key)
+  will be exposed. It is not possible to remove, revoke or rectify this information from the Radicle
+  Network. This is because the Radicle Network is a decentralized (public) peer-to-peer network (not
+  operated by us) which stores data committed to it around the world. Your use of a client and
+  interaction with Radicle Network will lead you to interact with other Radicle Network
+  participants; you should note that other participants on the Radicle Network may be able to
+  determine certain things about you through your use of the Radicle Network. Similarly, your use of
+  or interaction with the Funding Functions (as defined in the
+  <router-link to="/disclaimer">Disclaimer</router-link>) in the Radicle Network could lead other
+  Radicle Network participants to determine certain things about you through your use of the Funding
+  Functions.
+  <b>Radicle Foundation does neither collect this data from you nor process it in any way</b>.
+</p>
+<h2>How Personal Data is Used</h2>
+<h3>When subscribing to the Radicle newsletter:</h3>
+<p>
+  When you subscribe to the Radicle newsletter, the Foundation collects personal data via its
+  newsletter service provider MailChimp. This data may include:
+</p>
+<ol>
+  <li>your email address</li>
+  <li>the date and time of registration</li>
+  <li>your IP address</li>
+  <li>your browser type</li>
+  <li>your language</li>
+  <li>the preferred email format</li>
+</ol>
+<p>
+  This data is collected and processed for the purpose of subscribing you to and sending you
+  Radicle’s newsletter (via radicle.xyz) with updates on the project’s development as well as
+  ensuring the security and reliability of the newsletter service.
+</p>
+<p>
+  The legal basis for this processing is your consent as provided in the double opt-in confirmation
+  part of the Radicle newsletter sign-up process. This data will be stored as long as the Foundation
+  has your consent to send you a newsletter. If you wish to unsubscribe from the Radicle newsletter,
+  you can do so by clicking on the link at the end of each newsletter or by sending the Foundation
+  an email. You can read more about MailChimp’s data access as well as their legitimate interests in
+  and purposes for collecting this data <a
+    href="https://mailchimp.com/legal/privacy/#3._Privacy_for_Contacts"
+    target="_blank"
+    rel="noopener noreferrer">here</a
+  >.
+</p>
+<h3>When receiving the Radicle newsletter:</h3>
+<p>
+  If you have subscribed to the Radicle newsletter, each time you receive and open a newsletter, a
+  third-party service provider MailChimp collects data, including:
+</p>
+<ol>
+  <li>your email address</li>
+  <li>the date and time you opened the email</li>
+  <li>your location, as indicated by your IP address</li>
+</ol>
+<p>
+  This data is collected and processed by the Foundation for the purpose of ensuring the security
+  and reliability of the newsletter service as well as the Foundation’s legitimate interest in the
+  effectiveness of and general user interest in the Radicle newsletter. Because the Radicle
+  newsletter service is hosted by MailChimp, you can view more information about the data they
+  collect and their legitimate interests in and purposes for collecting this data <a
+    href="https://mailchimp.com/legal/privacy/#3._Privacy_for_Contacts"
+    target="_blank"
+    rel="noopener noreferrer">here</a
+  >.
+</p>
+<h3>When browsing the radicle.xyz website:</h3>
+<p>
+  If you go to the <a href="http://radicle.xyz" target="_blank" rel="noopener noreferrer"
+    >radicle.xyz website</a
+  >, the Foundation does not collect any of your information as you browse. However, the Radicle
+  website is hosted by Netlify, which collects access logs (including the IP addresses)
+  <a href="http://radicle.xyz" target="_blank" rel="noopener noreferrer">radicle.xyz</a>
+  visitors. This is stored for less than 30 days. For more information about the information collected,
+  visit Netlify’s privacy policies
+  <a href="https://www.netlify.com/privacy/" target="_blank" rel="noopener noreferrer">here</a>
+  and
+  <a href="https://www.netlify.com/gdpr-ccpa/" target="_blank" rel="noopener noreferrer">here</a>.
+</p>
+<h3>When browsing the drips.network and app.drips.network websites:</h3>
+<p>
+  If you go to the drips.network and app.drips.network websites, the Foundation does not collect any
+  of your information as you browse. However, these websites are hosted by Netlify, which collects
+  access logs (including the IP addresses) drips.network and app.drips.network visitors. This is
+  stored for less than 30 days. These websites have also enabled <a
+    href="https://www.netlify.com/products/analytics/"
+    target="_blank"
+    rel="noopener noreferrer">Netlify Analytics</a
+  >
+  to collect page hits. For more information about the information collected, visit Netlify’s privacy
+  policies
+  <a href="https://www.netlify.com/privacy/" target="_blank" rel="noopener noreferrer">here</a>
+  and
+  <a href="https://www.netlify.com/gdpr-ccpa/" target="_blank" rel="noopener noreferrer">here</a>.
+</p>
+<h3>When downloading Radicle:</h3>
+<p>
+  When you download Radicle binary files, Github servers may collect and save information regarding
+  the pages you view, the referring site, your IP address and information about your device, session
+  information, the date and time of each request, and telemetry data (i.e., information about how a
+  specific feature or service is performing) regarding your use of other features and functionality
+  of Github's service. They use this information to provide, administer, analyze, manage, and
+  operate their service. The Foundation does not collect, store, or process the information
+  collected by Github. For more information about the information Github collects and how it uses
+  this information, please visit <a
+    href="https://docs.github.com/en/site-policy/privacy-policies/github-privacy-statement#what-information-github-collects"
+    target="_blank"
+    rel="noopener noreferrer">Github’s privacy policies</a
+  >. Regarding your use of Radicle Technology Stack, the Foundation does not process any of your
+  personal data (see above: Data in P2P and Blockchain Infrastructures).
+</p>
+<h3>When you join the Radicle Matrix server:</h3>
+<p>
+  If you want to join Radicle’s Matrix server to chat with the Radicle community, you will need to
+  join it via a client. You have the option of creating a Matrix account on Radicle's server, hosted
+  by Ungleich; if you do, the Foundation, via Ungleich, collects your user name, display name, email
+  address (if you provided one to the client), and your IP address each time you access the Radicle
+  Matrix server. When you join a chat room on the Radicle Matrix server, whether you have an account
+  on Radicle’s server or not, the Foundation will collect your user name and display name. This
+  information is collected in order to deliver the chat service and enable its features, as well as
+  ensure the security and reliability of the service.
+</p>
+<h3>When you contribute to the Radicle Matrix server:</h3>
+<p>
+  Once you’ve joined Radicle’s Matrix server, you can participate in the public chat room by
+  contributing messages and files. When you contribute to Radicle’s Matrix server, everyone who has
+  joined the room will collect: your username, display name, message content, message files, and
+  message date/time. When you communicate directly with another user via a private room, the user
+  will collect: your username, display name, message content, message files, and message date/time.
+  This information, collected in public chat rooms or in private rooms, is stored on Radicle’s
+  Matrix homeserver, which is hosted by Ungleich.
+</p>
+<p>
+  This data is collected and processed by Ungleich for the purpose of delivering the chat service
+  and features, as well as ensuring the security and reliability of the chat service. You can view
+  more information about how they handle this data <a
+    href="https://redmine.ungleich.ch/projects/open-infrastructure/wiki/Security_and_Privacy_Policy"
+    target="_blank"
+    rel="noopener noreferrer">here</a
+  >. If you wish to leave the Radicle Matrix server and delete all the data that was contributed by
+  you, you can do so by sending the Foundation an email (ops@radicle.foundation).
+</p>
+<h2>How Third Party Applications are Used</h2>
+<h3>MailChimp:</h3>
+<p>
+  The Foundation uses MailChimp (based in the United States) to collect subscriber emails and to
+  send out the Radicle newsletter to subscribers. The Foundation hereby informs you and you hereby
+  acknowledge that the United States, in the view of the European Commission, does not ensure an
+  adequate level of protection of personal data and that the personal data can be transferred to the
+  recipients in the United States without any further safeguards; furthermore, during the newsletter
+  signup process, the user consents to this transfer of personal data and confirms their
+  understanding of the possible risks of such a transfer via the double opt-in confirmation part of
+  the newsletter signup process. MailChimp’s privacy policy can be found <a
+    href="https://mailchimp.com/legal/privacy/#3._Privacy_for_Contacts"
+    target="_blank"
+    rel="noopener noreferrer">here</a
+  >.
+</p>
+<h3>Netlify:</h3>
+<p>
+  The Radicle websites are hosted by Netlify. User personal information from visitors to the Radicle
+  websites, including logs of visitor IP addresses, may be collected by Netlify to comply with legal
+  obligations, and to maintain the security and integrity of the Website and the Service. For
+  further information and the applicable data protection provisions of Netlify, visit their privacy
+  policies <a href="https://www.netlify.com/privacy/" target="_blank" rel="noopener noreferrer"
+    >here</a
+  >
+  and
+  <a href="https://www.netlify.com/gdpr-ccpa/" target="_blank" rel="noopener noreferrer">here</a>.
+</p>
+<h3>Github:</h3>
+<p>
+  The Foundation uses Github servers to store Radicle binary files. For further information and the
+  applicable data protection provisions of Github, <a
+    href="https://docs.github.com/en/site-policy/privacy-policies/github-privacy-statement"
+    target="_blank"
+    rel="noopener noreferrer">visit this site</a
+  >.
+</p>
+<h3>Matrix:</h3>
+<p>
+  The Foundation has set up an instance of Matrix, a chat protocol, which enables users to securely
+  publish and subscribe to data. The Matrix Network is a decentralised and openly federated
+  communication network. This means that a user's messages are stored on both the homeserver where
+  they have their account and the Radicle Matrix homeserver, which hosts the Radicle community chat
+  room where the user makes their contributions. For more information about how Matrix works, you
+  can read their privacy policy <a
+    href="https://matrix.org/legal/privacy-notice"
+    target="_blank"
+    rel="noopener noreferrer">here</a
+  >.
+</p>
+<h3>Ungleich:</h3>
+<p>
+  The Foundation uses Ungleich to host an instance of Matrix and Radicle’s Matrix homeserver. A
+  username and display name is collected to give a user access to the chat room on Radicle’s Matrix
+  homeserver, then all contributions by the user to the Radicle chat room are stored on Radicle’s
+  homeserver. Optionally, a user can create a Matrix account on Radicle’s homeserver, in which case
+  Ungleich may store an email for the purpose of recovering their password as well as the user’s IP
+  address. Radicl’s Matrix homeserver is hosted in Ungleich’s own datacenter in Switzerland. For
+  further information about how Ungleich handles security and privacy concerns, <a
+    href="https://redmine.ungleich.ch/projects/open-infrastructure/wiki/Security_and_Privacy_Policy"
+    target="_blank"
+    rel="noopener noreferrer">visit this site</a
+  >.
+</p>
+<h3>Links to Social Media:</h3>
+<p>
+  On the Radicle websites, there are links to social media profiles. Those services might also
+  collect personal data. Please refer to their privacy policies for more information.
+</p>
+<ol>
+  <li>
+    <a href="https://discord.com/privacy" target="_blank" rel="noopener noreferrer">Discord</a>
+  </li>
+  <li>
+    <a href="https://twitter.com/de/privacy" target="_blank" rel="noopener noreferrer">Twitter</a>
+  </li>
+  <li>
+    <a href="https://radicle.community/privacy" target="_blank" rel="noopener noreferrer"
+      >Discourse</a
+    >
+  </li>
+  <li>
+    <a href="https://telegram.org/privacy" target="_blank" rel="noopener noreferrer">Telegram</a>
+  </li>
+  <li>
+    <a
+      href="https://help.github.com/en/articles/github-privacy-statement"
+      target="_blank"
+      rel="noopener noreferrer">GitHub</a
+    >
+  </li>
+  <li>
+    <a
+      href="https://www.notion.so/Terms-and-Privacy-28ffdd083dc3473e9c2da6ec011b58ac"
+      target="_blank"
+      rel="noopener noreferrer">Notion</a
+    >
+  </li>
+</ol>
+<h2>Storing Your Personal Data</h2>
+<p>
+  The Foundation retains your information only for as long as is necessary for the purposes for
+  which it processes the information as set out in this policy. However, the Foundation may retain
+  your personal data for a longer period of time where such retention is necessary for compliance
+  with a legal obligation to which the Foundation is subject, or in order to protect your vital
+  interests or the vital interests of another natural person.
+</p>
+<h2>Transferring Data Outside the EU</h2>
+<p>
+  The Radicle newsletter subscription function is realized with the help of MailChimp, which is
+  based in the United States (see above).
+</p>
+<p>
+  Furthermore, any metadata associated with contributions made while using Radicle (including your
+  git username and, potentially, your email address if it’s associated with your git username) may
+  be replicated and stored around the world.
+</p>
+<h2>User Rights Under GDPR</h2>
+<p>
+  The Radicle Foundation takes user rights and privacy seriously - and this philosophy is built into
+  each one of the projects it supports. The Foundation has limited the data collected to the
+  absolute minimum it needs to enable the projects to work for the user.
+</p>
+<p>
+  MailChimp makes the assurance that they take the appropriate security measures to prevent access
+  to the Radicle newsletter subscriber list for any purpose other than the purpose of using it to
+  inform supporters of Radicle’s progress. Furthermore, as a Radicle newsletter subscriber and a
+  contributor to the Radicle Community Matrix, you have the right to information, correction,
+  limitation of data processing, deletion of personal data, objection, revocation of the declaration
+  of consent under data protection law for the future and data transferability within the framework
+  of the data protection law applicable to you and to the extent provided for therein (such as in
+  the case of the GDPR). Please note that while the Foundation can delete your data from the Radicle
+  Matrix homeserver, this does not apply to the data on Matrix servers run by others, including,
+  potentially, the homeserver where you have your Matrix account.
+</p>
+<p>
+  In addition, you have the right to assert your claims in court or to file a complaint with the
+  responsible data protection authority. Switzerland's competent data protection authority is the
+  Federal Data Protection and Information Commissioner.
+</p>
+<p>
+  However, because of the Radicle Network’s peer-to-peer, gossip-based code collaboration
+  infrastructure, the deletion or editing of any contributions you make to your or other
+  repositories on the Radicle Network and any personal data made available to the public in this
+  regard (see above: Data in P2P and Blockchain Infrastructures) cannot be (fully) enforced. This is
+  because Radicle Network is a decentralized network and it stores data committed to it around the
+  world. The Foundation can only ensure your rights regarding data for which the Foundation
+  qualifies as a controller (data processed by the Radicle Foundation – see above: How Personal Data
+  is Used).
+</p>
+<h2>Contact</h2>
+<p>
+  The Radicle websites are maintained on a voluntary basis by the Radicle Foundation. The Foundation
+  is registered in the canton of Zug, Switzerland, under the commercial register number
+  CHE405.696.942 [CHE-405.696.942 MWST]. The Foundation’s registered office is located at:
+</p>
+<p>Suurstoffi 37<br />6343 Rotkreuz<br />Switzerland</p>
+<p>
+  If you have any queries concerning the Radicle websites, other Radicle communication channels, or
+  your rights under this Privacy Policy, please contact <a href="mailto:ops@radicle.foundation"
+    >ops@radicle.foundation</a
+  >.
 </p>
 
 <style>
@@ -44,7 +377,23 @@
     margin-bottom: 2rem;
   }
 
-  p {
+  h2,
+  h3 {
+    margin-top: 2rem;
+    margin-bottom: 1.5rem;
+  }
+
+  p,
+  ol {
     margin-bottom: 1rem;
+  }
+
+  ol li {
+    list-style: initial;
+    margin-left: 1rem;
+  }
+
+  a {
+    text-decoration: underline;
   }
 </style>


### PR DESCRIPTION
Includes

- new beta badge next to LP header drips logo
- adjusted beta notice copy on LP
- links back to Drips v1 in LP beta notice, footer
- new /legal/privacy, /legal/access and /legal/disclaimer pages
- links to legal pages in LP footer and account menu