### PR TITLE
feat: save & restore input values in all flows

### DIFF
--- a/src/lib/components/amount/amount.svelte
+++ b/src/lib/components/amount/amount.svelte
@@ -77,6 +77,7 @@
   .wrapper {
     display: flex;
     flex-direction: column;
+    user-select: none;
   }
 
   .unknown {

--- a/src/lib/components/carousel/items/edu-card.svelte
+++ b/src/lib/components/carousel/items/edu-card.svelte
@@ -52,6 +52,7 @@
     overflow: hidden;
     align-items: center;
     height: 100%;
+    user-select: none;
   }
 
   .illustration-outer {

--- a/src/lib/components/section-header/section-header.svelte
+++ b/src/lib/components/section-header/section-header.svelte
@@ -36,6 +36,7 @@
     gap: 0.5rem;
     align-items: center;
     justify-content: space-between;
+    user-select: none;
   }
 
   .icon-wrapper {

--- a/src/lib/components/step-header/step-header.svelte
+++ b/src/lib/components/step-header/step-header.svelte
@@ -17,6 +17,7 @@
     display: flex;
     flex-direction: column;
     gap: 1rem;
+    user-select: none;
   }
 
   p {

--- a/src/lib/components/stepper/stepper.svelte
+++ b/src/lib/components/stepper/stepper.svelte
@@ -10,7 +10,8 @@
   import modal from '$lib/stores/modal';
 
   export let steps: Steps;
-  export let context: Writable<unknown> | undefined = undefined;
+  export let context: (() => Writable<unknown>) | undefined = undefined;
+  const resolvedContext = context?.();
 
   let stepElement: HTMLDivElement;
 
@@ -228,7 +229,7 @@
             on:conclude={handleConclusion}
             on:sidestep={handleSidestep}
             {...currentStep.props}
-            {context}
+            context={resolvedContext}
           />
         {/if}
       </div>

--- a/src/lib/components/stepper/utils/transact.ts
+++ b/src/lib/components/stepper/utils/transact.ts
@@ -74,7 +74,7 @@ function setStepCopyWaitingForSignature(
     customMessage ?? {
       message: safeAppMode
         ? 'Waiting for you to propose the transaction to your safe...'
-        : 'Waiting for you to sign the transaction in your wallet...',
+        : 'Waiting for you to confirm the transaction in your wallet...',
       icon: {
         component: Emoji,
         props: {
@@ -94,7 +94,7 @@ function setStepCopyWaitingForConfirmation(
 ) {
   updateAwaitStep(
     customMessage ?? {
-      message: 'Waiting for your transaction to be confirmed',
+      message: 'Waiting for your transaction to be confirmed on the network.',
       link: {
         url: etherscanLink(networkName, txHash),
         label: 'View on Etherscan',

--- a/src/lib/components/toggleable/toggleable.svelte
+++ b/src/lib/components/toggleable/toggleable.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
+  import { onMount, tick } from 'svelte';
   import { sineInOut } from 'svelte/easing';
   import { tweened } from 'svelte/motion';
   import Toggle from '../toggle/toggle.svelte';
@@ -33,7 +33,9 @@
     setTabIndexRecursively(contentElem, '-1');
   }
 
-  function expand() {
+  async function expand() {
+    await tick();
+
     const updateHeight = (instant: boolean) => {
       const newHeight = contentElem.getBoundingClientRect().height;
       contentHeight.set(newHeight, { duration: instant ? 0 : 300, easing: sineInOut });

--- a/src/lib/flows/collect-flow/collect-amounts.svelte
+++ b/src/lib/flows/collect-flow/collect-amounts.svelte
@@ -38,6 +38,8 @@
 
   export let context: Writable<CollectFlowState>;
 
+  const restorer = $context.restorer;
+
   $: cycle = $context.currentDripsCycle ?? unreachable();
   $: currentCycleEnd = new Date(cycle.start.getTime() + cycle.durationMillis);
 
@@ -108,8 +110,8 @@
     }),
   );
 
-  let squeezeEnabled = false;
-  let selectedSqueezeSenderItems: string[] = [];
+  let squeezeEnabled = restorer.restore('squeezeEnabled');
+  let selectedSqueezeSenderItems: string[] = restorer.restore('selectedSqueezeSenderItems');
 
   $: totalSelectedSqueezeAmount = squeezeEnabled
     ? selectedSqueezeSenderItems.reduce<bigint>(
@@ -209,6 +211,11 @@
       }),
     );
   }
+
+  $: restorer.saveAll({
+    squeezeEnabled,
+    selectedSqueezeSenderItems,
+  });
 </script>
 
 <StepLayout>

--- a/src/lib/flows/collect-flow/collect-flow-state.ts
+++ b/src/lib/flows/collect-flow/collect-flow-state.ts
@@ -1,6 +1,12 @@
+import { newRestorer, type Restorer } from '$lib/utils/restorer';
 import type { ContractReceipt } from 'ethers';
 import type { SplitsEntry } from 'radicle-drips';
 import { writable } from 'svelte/store';
+
+type Restorable = {
+  squeezeEnabled: boolean;
+  selectedSqueezeSenderItems: string[];
+};
 
 export interface CollectFlowState {
   tokenAddress?: string;
@@ -19,6 +25,11 @@ export interface CollectFlowState {
   amountCollected?: bigint;
   squeezeEnabled?: boolean;
   receipt?: ContractReceipt;
+  restorer: Restorer<Restorable>;
 }
 
-export default writable<CollectFlowState>({});
+export default (tokenAddress?: string) =>
+  writable<CollectFlowState>({
+    tokenAddress,
+    restorer: newRestorer<Restorable>({ squeezeEnabled: false, selectedSqueezeSenderItems: [] }),
+  });

--- a/src/lib/flows/collect-flow/collect-flow-steps.ts
+++ b/src/lib/flows/collect-flow/collect-flow-steps.ts
@@ -4,8 +4,6 @@ import FetchCollectableAmounts from './fetch-collectable-amounts.svelte';
 import CollectAmountsStep from './collect-amounts.svelte';
 import { makeStep } from '$lib/components/stepper/types';
 import mapFilterUndefined from '$lib/utils/map-filter-undefined';
-import { isAddress } from 'ethers/lib/utils';
-import assert from '$lib/utils/assert';
 import { get } from 'svelte/store';
 import walletStore from '$lib/stores/wallet/wallet.store';
 import SuccessStep from '$lib/components/success-step/success-step.svelte';
@@ -13,16 +11,10 @@ import tokens from '$lib/stores/tokens';
 import unreachable from '$lib/utils/unreachable';
 
 export default function getCollectFlowSteps(tokenAddress: string | undefined = undefined) {
-  if (tokenAddress) {
-    assert(isAddress(tokenAddress));
-    collectFlowState.update((c) => ({
-      ...c,
-      tokenAddress,
-    }));
-  }
+  const ctx = collectFlowState(tokenAddress);
 
   return {
-    context: collectFlowState,
+    context: () => ctx,
     steps: mapFilterUndefined(
       [
         // need to select token?
@@ -44,7 +36,7 @@ export default function getCollectFlowSteps(tokenAddress: string | undefined = u
           component: SuccessStep,
           props: {
             message: `Your ${
-              tokens.getByAddress(get(collectFlowState).tokenAddress ?? unreachable())?.info.symbol
+              tokens.getByAddress(get(ctx).tokenAddress ?? unreachable())?.info.symbol
             } earnings have successfully been delivered to your wallet address.`,
             safeAppMode: Boolean(get(walletStore).safe),
           },

--- a/src/lib/flows/create-stream-flow/create-stream-flow-state.ts
+++ b/src/lib/flows/create-stream-flow/create-stream-flow-state.ts
@@ -1,0 +1,24 @@
+import { newRestorer, type Restorer } from '$lib/utils/restorer';
+import { writable } from 'svelte/store';
+
+type Restorable = {
+  streamNameValue: string | undefined;
+  amountValue: string | undefined;
+  selectedTokenAddress: string[] | undefined;
+  selectedMultiplier: string;
+  recipientAddressValue: string | undefined;
+  streamStartDateValue: string | undefined;
+  streamStartTimeValue: string | undefined;
+  streamEndDateValue: string | undefined;
+  streamEndTimeValue: string | undefined;
+  setStartAndEndDate: boolean;
+};
+
+export interface CreateStreamFlowState {
+  restorer: Restorer<Restorable>;
+}
+
+export default () =>
+  writable<CreateStreamFlowState>({
+    restorer: newRestorer<Restorable>({ selectedMultiplier: '1', setStartAndEndDate: false }),
+  });

--- a/src/lib/flows/create-stream-flow/create-stream-flow-steps.ts
+++ b/src/lib/flows/create-stream-flow/create-stream-flow-steps.ts
@@ -2,10 +2,11 @@ import { makeStep } from '$lib/components/stepper/types';
 import SuccessStep from '$lib/components/success-step/success-step.svelte';
 import walletStore from '$lib/stores/wallet/wallet.store';
 import { get } from 'svelte/store';
+import createStreamFlowState from './create-stream-flow-state';
 import InputDetails from './input-details.svelte';
 
 export default (tokenAddress?: string) => ({
-  context: undefined,
+  context: createStreamFlowState,
   steps: [
     makeStep({
       component: InputDetails,

--- a/src/lib/flows/create-stream-flow/input-details.svelte
+++ b/src/lib/flows/create-stream-flow/input-details.svelte
@@ -214,7 +214,7 @@
   </FormField>
   <FormField title="Stream to*">
     <InputAddress
-      bind:validatedValue={recipientAddressValue}
+      bind:value={recipientAddressValue}
       on:validationChange={onAddressValidationChange}
     />
   </FormField>

--- a/src/lib/flows/edit-splits-flow/edit-splits-flow-state.ts
+++ b/src/lib/flows/edit-splits-flow/edit-splits-flow-state.ts
@@ -1,8 +1,15 @@
+import { newRestorer, type Restorer } from '$lib/utils/restorer';
 import type { SplitsEntry } from 'radicle-drips';
 import { writable } from 'svelte/store';
+import type { SplitInput } from './edit-splits-inputs.svelte';
+
+type Restorable = {
+  splitsInputs: SplitInput[] | undefined;
+};
 
 export interface EditSplitsFlowState {
   splits: SplitsEntry[];
+  restorer: Restorer<Restorable>;
 }
 
-export default writable<EditSplitsFlowState>({ splits: [] });
+export default writable<EditSplitsFlowState>({ splits: [], restorer: newRestorer<Restorable>({}) });

--- a/src/lib/flows/edit-splits-flow/edit-splits-flow-steps.ts
+++ b/src/lib/flows/edit-splits-flow/edit-splits-flow-steps.ts
@@ -7,7 +7,7 @@ import EditSplitsInputs from './edit-splits-inputs.svelte';
 import FetchSplits from './fetch-splits.svelte';
 
 export default (afterTx: () => Promise<void>) => ({
-  context: editSplitsFlowState,
+  context: () => editSplitsFlowState,
   steps: [
     makeStep({
       component: FetchSplits,

--- a/src/lib/flows/edit-splits-flow/edit-splits-inputs.svelte
+++ b/src/lib/flows/edit-splits-flow/edit-splits-inputs.svelte
@@ -1,3 +1,10 @@
+<script context="module" lang="ts">
+  export interface SplitInput {
+    receiver: { value: string; type: string };
+    amount: string | number | undefined; // percent and eventually points
+  }
+</script>
+
 <script lang="ts">
   import Button from '$lib/components/button/button.svelte';
   import StepHeader from '$lib/components/step-header/step-header.svelte';
@@ -21,12 +28,9 @@
   export let context: Writable<EditSplitsFlowState>;
   export let afterTx: (() => Promise<void>) | undefined = undefined;
 
-  const dispatch = createEventDispatcher<StepComponentEvents>();
+  const restorer = $context.restorer;
 
-  interface SplitInput {
-    receiver: { value: string; type: string };
-    amount: string | number | undefined; // percent and eventually points
-  }
+  const dispatch = createEventDispatcher<StepComponentEvents>();
 
   const emptyRow = (): SplitInput => {
     return { receiver: { value: '', type: 'unvalidated' }, amount: undefined };
@@ -36,7 +40,11 @@
   let addressContainers: HTMLDivElement[] = [];
   let validationError: string;
 
-  if ($context.splits.length) {
+  const restoredSplitsInputs = restorer.restore('splitsInputs');
+
+  if (restoredSplitsInputs) {
+    splitsInputs = restoredSplitsInputs;
+  } else if ($context.splits.length) {
     // fill-in existing splits?
     $context.splits.forEach(async (s) => {
       const row = emptyRow();
@@ -111,6 +119,10 @@
       }),
     );
   }
+
+  $: restorer.saveAll({
+    splitsInputs,
+  });
 </script>
 
 <StepLayout>

--- a/src/lib/flows/edit-stream-flow/edit-stream-flow-state.ts
+++ b/src/lib/flows/edit-stream-flow/edit-stream-flow-state.ts
@@ -1,0 +1,17 @@
+import { newRestorer, type Restorer } from '$lib/utils/restorer';
+import { writable } from 'svelte/store';
+
+type Restorable = {
+  newAmountValue: string | undefined;
+  newName: string | undefined;
+  newSelectedMultiplier: string;
+};
+
+export interface EditStreamFlowState {
+  restorer: Restorer<Restorable>;
+}
+
+export default () =>
+  writable<EditStreamFlowState>({
+    restorer: newRestorer<Restorable>({ newSelectedMultiplier: '1' }),
+  });

--- a/src/lib/flows/edit-stream-flow/edit-stream-flow-steps.ts
+++ b/src/lib/flows/edit-stream-flow/edit-stream-flow-steps.ts
@@ -3,10 +3,11 @@ import SuccessStep from '$lib/components/success-step/success-step.svelte';
 import type { Stream } from '$lib/stores/streams/types';
 import walletStore from '$lib/stores/wallet/wallet.store';
 import { get } from 'svelte/store';
+import editStreamFlowState from './edit-stream-flow-state';
 import EnterNewDetails from './enter-new-details.svelte';
 
 export default (stream: Stream) => ({
-  context: undefined,
+  context: editStreamFlowState,
   steps: [
     makeStep({
       component: EnterNewDetails,

--- a/src/lib/flows/top-up-flow/enter-amount.svelte
+++ b/src/lib/flows/top-up-flow/enter-amount.svelte
@@ -28,7 +28,11 @@
   $: tokenAddress = $context.tokenAddress;
   $: tokenInfo = tokenAddress ? tokens.getByAddress(tokenAddress) ?? unreachable() : unreachable();
 
-  let amountValue = '0';
+  const restorer = $context.restorer;
+
+  let amountValue = restorer.restore('amountValue');
+  $: restorer.save({ amountValue });
+
   let validationState: TextInputValidationState = {
     type: 'unvalidated',
   };

--- a/src/lib/flows/top-up-flow/top-up-flow-state.ts
+++ b/src/lib/flows/top-up-flow/top-up-flow-state.ts
@@ -1,10 +1,19 @@
+import { newRestorer, type Restorer } from '$lib/utils/restorer';
 import { writable } from 'svelte/store';
 
+type Restorable = {
+  amountValue: string;
+};
 export interface TopUpFlowState {
   tokenAddress?: string;
   tokenAllowance?: bigint;
   tokenBalance?: bigint;
   amountToTopUp?: bigint;
+  restorer: Restorer<Restorable>;
 }
 
-export default writable<TopUpFlowState>({});
+export default (tokenAddress: string | undefined) =>
+  writable<TopUpFlowState>({
+    restorer: newRestorer<Restorable>({ amountValue: '0' }),
+    tokenAddress,
+  });

--- a/src/lib/flows/top-up-flow/top-up-flow-steps.ts
+++ b/src/lib/flows/top-up-flow/top-up-flow-steps.ts
@@ -31,12 +31,10 @@ function getSuccessMessage(state: TopUpFlowState) {
 }
 
 export default function getTopUpFlowSteps(tokenAddress?: string) {
-  topUpFlowState.set({
-    tokenAddress,
-  });
+  const ctx = topUpFlowState(tokenAddress);
 
   return {
-    context: topUpFlowState,
+    context: () => ctx,
     steps: [
       tokenAddress
         ? makeStep({
@@ -59,7 +57,7 @@ export default function getTopUpFlowSteps(tokenAddress?: string) {
         component: SuccessStep,
         props: {
           safeAppMode: Boolean(get(walletStore).safe),
-          message: () => getSuccessMessage(get(topUpFlowState)),
+          message: () => getSuccessMessage(get(ctx)),
         },
       }),
     ],

--- a/src/lib/flows/withdraw-flow/enter-amount.svelte
+++ b/src/lib/flows/withdraw-flow/enter-amount.svelte
@@ -33,14 +33,16 @@
 
   export let context: Writable<WithdrawFlowState>;
 
+  const restorer = $context.restorer;
+
   $: tokenInfo = tokens.getByAddress($context.tokenAddress) ?? unreachable();
   $: estimate =
     $balances.accounts[String($wallet.dripsUserId) ?? unreachable()].tokens[$context.tokenAddress]
       .total.totals.remainingBalance;
 
-  let amount: string | undefined;
+  let amount = restorer.restore('amount');
   let amountWei: bigint | undefined;
-  let withdrawAll = false;
+  let withdrawAll = restorer.restore('withdrawAll');
   $: if (withdrawAll) {
     amount = formatUnits(
       estimate / BigInt(constants.AMT_PER_SEC_MULTIPLIER),
@@ -146,6 +148,11 @@
       }),
     );
   }
+
+  $: restorer.saveAll({
+    withdrawAll,
+    amount,
+  });
 </script>
 
 <StepLayout>

--- a/src/lib/flows/withdraw-flow/withdraw-flow-state.ts
+++ b/src/lib/flows/withdraw-flow/withdraw-flow-state.ts
@@ -1,8 +1,19 @@
+import { newRestorer, type Restorer } from '$lib/utils/restorer';
 import { writable } from 'svelte/store';
+
+type Restorable = {
+  withdrawAll: boolean;
+  amount: string | undefined;
+};
 
 export interface WithdrawFlowState {
   tokenAddress: string;
   amountToWithdraw?: bigint;
+  restorer: Restorer<Restorable>;
 }
 
-export default (tokenAddress: string) => writable<WithdrawFlowState>({ tokenAddress });
+export default (tokenAddress: string) =>
+  writable<WithdrawFlowState>({
+    tokenAddress,
+    restorer: newRestorer<Restorable>({ withdrawAll: false }),
+  });

--- a/src/lib/flows/withdraw-flow/withdraw-flow-steps.ts
+++ b/src/lib/flows/withdraw-flow/withdraw-flow-steps.ts
@@ -9,7 +9,7 @@ export default function getWithdrawSteps(tokenAddress: string) {
   const state = withdrawFlowState(tokenAddress);
 
   return {
-    context: state,
+    context: () => state,
     steps: [
       makeStep({
         component: EnterAmount,

--- a/src/lib/utils/restorer.ts
+++ b/src/lib/utils/restorer.ts
@@ -1,0 +1,77 @@
+import { get, writable } from 'svelte/store';
+
+type FilterMembers<T, C> = {
+  [K in keyof T]: T[K] extends C ? K : never;
+};
+
+type FilterKeys<T, C> = FilterMembers<T, C>[keyof T];
+
+type FilterTypeMembers<T, C> = Pick<T, FilterKeys<T, C>>;
+
+/**
+ * A utility that saves certain inputs and can restore them on demand. Useful for saving inputs in a flow step, and restoring
+ * them when the user comes back after an error, for example.
+ *
+ * Pass a type describing all values this particular restorer should keep track of as the first type argument.
+ *
+ * **Example**
+ *
+ * ```ts
+ * const restorer = newRestorer<{ foo: string | undefined, bar: number | undefined }>()
+ *
+ * // ⬇️ Automatically typed as string | undefined
+ * let foo = restorer.restore('foo'); // -> returns undefined
+ *
+ * // ⬇️ Foo is automatically typed as string | undefined
+ * restorer.save({ foo: 'wassup' });
+ *
+ * foo = restorer.restore('foo'); // -> returns 'wassup'
+ * ```
+ *
+ * If you include non-nullable values in your restorable types, you need to initially define them when creating
+ * the restorer.
+ *
+ * **Example**
+ *
+ * ```ts
+ * const restorer = newRestorer<{ optionalVal: string | undefined, requiredVal: string }>({ requiredVal: 'hello' });
+ * ```
+ *
+ * @param defaults Initial values for any non-nullable restorables defined in the type argument.
+ * @returns A new restorer instance.
+ */
+export function newRestorer<T extends Record<string, unknown>>(
+  defaults: FilterTypeMembers<T, NonNullable<unknown>>,
+) {
+  const state = writable<T>(defaults as T);
+
+  function save(vals: Partial<T>): void {
+    const filteredVals = Object.fromEntries(Object.entries(vals).filter((e) => e[1] !== undefined));
+
+    state.update((s) => ({ ...s, ...filteredVals }));
+  }
+
+  function saveAll(vals: T): void {
+    state.set(vals);
+  }
+
+  function restore<K extends keyof T>(key: K): T[K] {
+    const s = get(state);
+
+    return (s ?? {})[key];
+  }
+
+  function clear() {
+    state.set({} as T);
+  }
+
+  return {
+    subscribe: state.subscribe,
+    save,
+    saveAll,
+    restore,
+    clear,
+  };
+}
+
+export type Restorer<T extends Record<string, unknown>> = ReturnType<typeof newRestorer<T>>;


### PR DESCRIPTION
Automatically saves & restores form inputs within stepper flows after coming back to a step (e.g. after an error or declining a transaction and clicking "try again")

Resolves #192 