### PR TITLE
feat: show "back to drips v1" card on profiles

### DIFF
--- a/src/lib/components/banner/banner.svelte
+++ b/src/lib/components/banner/banner.svelte
@@ -25,7 +25,7 @@
     </div>
   </div>
   <div class="right">
-    <a href={button.href}>
+    <a href={button.href} rel="noreferrer" target="_blank">
       <Button variant="primary">
         {button.label}
       </Button>

--- a/src/lib/components/banner/banner.svelte
+++ b/src/lib/components/banner/banner.svelte
@@ -26,12 +26,12 @@
   </div>
   <div class="right">
     <a href={button.href}>
-      <Button>
+      <Button variant="primary">
         {button.label}
       </Button>
     </a>
     <button class="close-button" on:click={() => dispatch('dismiss')}>
-      <CrossSmall style="fill: var(--color-caution-level-6)" />
+      <CrossSmall style="fill: var(--color-primary-level-6)" />
     </button>
   </div>
 </div>
@@ -39,15 +39,15 @@
 <style>
   .banner {
     position: relative;
-    background-color: var(--color-caution-level-1);
+    background-color: var(--color-primary-level-1);
     display: flex;
     gap: 1rem;
     justify-content: space-between;
     padding: 1rem 2rem 1rem 1rem;
     border-radius: 5rem 0 5rem 5rem;
-    color: var(--color-caution-level-6);
+    color: var(--color-primary-level-6);
     align-items: center;
-    border: 1px solid var(--color-caution);
+    border: 1px solid var(--color-primary);
   }
 
   .left,
@@ -63,7 +63,7 @@
     padding: 0.75rem;
     background-color: var(--color-background);
     border-radius: 2rem;
-    border: 1px solid var(--color-caution);
+    border: 1px solid var(--color-primary);
   }
 
   .left .text {
@@ -78,11 +78,11 @@
   }
 
   .close-button:hover {
-    background-color: var(--color-caution-level-2);
+    background-color: var(--color-primary-level-2);
   }
 
   .close-button:focus {
-    background-color: var(--color-caution-level-3);
+    background-color: var(--color-primary-level-3);
   }
 
   @media (max-width: 1056px) {

--- a/src/lib/components/banner/banner.svelte
+++ b/src/lib/components/banner/banner.svelte
@@ -1,0 +1,119 @@
+<script lang="ts">
+  import CrossSmall from 'radicle-design-system/icons/CrossSmall.svelte';
+  import { createEventDispatcher, type SvelteComponent } from 'svelte';
+  import Button from '../button/button.svelte';
+
+  const dispatch = createEventDispatcher<{ dismiss: undefined }>();
+
+  export let title: string;
+  export let description: string;
+  export let button: {
+    href: string;
+    label: string;
+  };
+  export let icon: typeof SvelteComponent;
+</script>
+
+<div class="banner">
+  <div class="left">
+    <div class="icon">
+      <svelte:component this={icon} />
+    </div>
+    <div class="text">
+      <h3 class="pixelated">{title}</h3>
+      <p class="typo-text">{description}</p>
+    </div>
+  </div>
+  <div class="right">
+    <a href={button.href}>
+      <Button>
+        {button.label}
+      </Button>
+    </a>
+    <button class="close-button" on:click={() => dispatch('dismiss')}>
+      <CrossSmall style="fill: var(--color-caution-level-6)" />
+    </button>
+  </div>
+</div>
+
+<style>
+  .banner {
+    position: relative;
+    background-color: var(--color-caution-level-1);
+    display: flex;
+    gap: 1rem;
+    justify-content: space-between;
+    padding: 1rem 2rem 1rem 1rem;
+    border-radius: 5rem 0 5rem 5rem;
+    color: var(--color-caution-level-6);
+    align-items: center;
+    border: 1px solid var(--color-caution);
+  }
+
+  .left,
+  .right {
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+  }
+
+  .left .icon {
+    height: 4rem;
+    width: 4rem;
+    padding: 0.75rem;
+    background-color: var(--color-background);
+    border-radius: 2rem;
+    border: 1px solid var(--color-caution);
+  }
+
+  .left .text {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  .close-button {
+    transition: background-color 0.3s;
+    border-radius: 1rem;
+  }
+
+  .close-button:hover {
+    background-color: var(--color-caution-level-2);
+  }
+
+  .close-button:focus {
+    background-color: var(--color-caution-level-3);
+  }
+
+  @media (max-width: 1056px) {
+    .banner {
+      flex-direction: column;
+      border-radius: 2rem 0 2rem 2rem;
+      align-items: flex-start;
+      justify-content: flex-end;
+      padding: 0.75rem;
+    }
+
+    .left .icon {
+      height: 3.25rem;
+      width: 3.25rem;
+    }
+
+    .left,
+    .right {
+      flex-direction: column;
+      align-items: flex-start;
+    }
+
+    .close-button {
+      position: absolute;
+      top: 0.75rem;
+      right: 0.75rem;
+    }
+
+    .right {
+      justify-content: flex-end;
+      flex-grow: 1;
+    }
+  }
+</style>

--- a/src/lib/components/illustrations/drips-v1-logo.svelte
+++ b/src/lib/components/illustrations/drips-v1-logo.svelte
@@ -1,0 +1,42 @@
+<svg viewBox="0 0 68 79" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path
+    fill-rule="evenodd"
+    clip-rule="evenodd"
+    d="M36.2389 0.89033C34.984 -0.296779 33.0147 -0.296776 31.7598 0.890334L11.2634 20.2799C11.1128 20.4224 10.9799 20.5727 10.8642 20.729C4.18124 26.8698 0 35.6377 0 45.3715C0 63.944 15.2223 79 34 79C52.7777 79 68 63.944 68 45.3715C68 35.6357 63.817 26.8662 57.1317 20.7253C57.0166 20.5703 56.8847 20.4213 56.7353 20.2799L36.2389 0.89033Z"
+    fill="url(#paint0_radial_1277_21738)"
+  />
+  <defs>
+    <radialGradient
+      id="paint0_radial_1277_21738"
+      cx="0"
+      cy="0"
+      r="1"
+      gradientUnits="userSpaceOnUse"
+      gradientTransform="translate(34 44.326) rotate(-90) scale(30.1146 28.8579)"
+    >
+      <stop stop-color="#16F336" />
+      <stop offset="0.0666667" stop-color="#17F238" />
+      <stop offset="0.133333" stop-color="#18ED3C" />
+      <stop offset="0.2" stop-color="#1BE643" />
+      <stop offset="0.266667" stop-color="#1EDB4E" />
+      <stop offset="0.333333" stop-color="#23CD5B" />
+      <stop offset="0.4" stop-color="#28BD6B" />
+      <stop offset="0.466667" stop-color="#2EAB7D" />
+      <stop offset="0.533333" stop-color="#34988F" />
+      <stop offset="0.6" stop-color="#3A86A0" />
+      <stop offset="0.666667" stop-color="#3F75B0" />
+      <stop offset="0.733333" stop-color="#4367BE" />
+      <stop offset="0.8" stop-color="#475CC8" />
+      <stop offset="0.866667" stop-color="#4955CF" />
+      <stop offset="0.933333" stop-color="#4B50D4" />
+      <stop offset="1" stop-color="#4B4FD5" />
+    </radialGradient>
+  </defs>
+</svg>
+
+<style>
+  svg {
+    width: 100%;
+    height: 100%;
+  }
+</style>

--- a/src/routes/app/[userId]/+page.svelte
+++ b/src/routes/app/[userId]/+page.svelte
@@ -12,8 +12,13 @@
   import SocialLink from '$lib/components/social-link/social-link.svelte';
   import unreachable from '$lib/utils/unreachable';
   import SectionSkeleton from '$lib/components/section-skeleton/section-skeleton.svelte';
-  import { fade } from 'svelte/transition';
+  import { fade, fly } from 'svelte/transition';
   import decodeUserId from '$lib/utils/decode-user-id';
+  import dismissablesStore from '$lib/stores/dismissables/dismissables.store';
+  import CrossSmall from 'radicle-design-system/icons/CrossSmall.svelte';
+  import DripsV1Logo from '$lib/components/illustrations/drips-v1-logo.svelte';
+  import Button from '$lib/components/button/button.svelte';
+  import TransitionedHeight from '$lib/components/transitioned-height/transitioned-height.svelte';
 
   $: userId = $page.params.userId;
 
@@ -93,6 +98,10 @@
   }
 
   $: dripsUserId && fetchRequestedAccount(dripsUserId);
+
+  function getDripsV1Url(address: string, ensName?: string) {
+    return `https://app.v1.drips.network/${ensName ?? address}`;
+  }
 </script>
 
 <svelte:head>
@@ -132,10 +141,46 @@
     <Balances userId={dripsUserId} />
     <Streams userId={dripsUserId} />
     <Splits userId={dripsUserId} />
+    <TransitionedHeight>
+      {#if address && !$dismissablesStore.includes('profile-drips-v1')}
+        <div out:fly|local={{ duration: 300, y: 16 }} class="drips-v1-card">
+          <button
+            class="close-button"
+            on:click={() => dismissablesStore.dismiss('profile-drips-v1')}
+          >
+            <CrossSmall />
+          </button>
+          <div class="top">
+            <div class="logo">
+              <DripsV1Logo />
+            </div>
+          </div>
+          <div class="bottom">
+            <h3 class="pixelated">Looking for Drips V1?</h3>
+            <p class="typo-text-small">
+              The new Drips is now in public beta. You can still access Drips V1 at
+              app.v1.drips.network.
+            </p>
+            <div class="action">
+              <a href={getDripsV1Url(address, $ens[address]?.name)} target="_blank" rel="noreferrer"
+                ><Button variant="normal">View profile on Drips V1</Button></a
+              >
+            </div>
+          </div>
+        </div>
+      {/if}
+    </TransitionedHeight>
   </div>
 {/if}
 
 <style>
+  .top {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 2rem;
+  }
+
   .identity {
     display: flex;
     gap: 1.5rem;
@@ -146,6 +191,49 @@
     display: flex;
     flex-direction: column;
     gap: 2rem;
+  }
+
+  .drips-v1-card {
+    border: 1px solid var(--color-foreground);
+    border-radius: 1.5rem 0 1.5rem 1.5rem;
+    width: 100%;
+    max-width: 24rem;
+    position: relative;
+    overflow: hidden;
+  }
+
+  .drips-v1-card > .close-button {
+    position: absolute;
+    top: 0.25rem;
+    right: 0.25rem;
+  }
+
+  .drips-v1-card > .top {
+    background-color: var(--color-primary-level-1);
+    padding: 0.75rem 0.75rem 0 0.75rem;
+    max-height: 3rem;
+  }
+
+  .drips-v1-card > .top > .logo {
+    background-color: var(--color-background);
+    padding: 0.75rem;
+    border-radius: 100rem;
+    width: 4rem;
+    height: 4rem;
+    transform: translateY(1rem);
+    border: 1px solid var(--color-primary-level-1);
+  }
+
+  .drips-v1-card > .bottom {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    padding: 3rem 0.75rem 0.75rem 0.75rem;
+  }
+
+  .drips-v1-card > .bottom > .action {
+    display: flex;
+    margin-top: 0.25rem;
   }
 
   .profile {
@@ -174,5 +262,12 @@
     -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;
     overflow: hidden;
+  }
+
+  @media (max-width: 1056px) {
+    .top {
+      flex-direction: column;
+      align-items: flex-start;
+    }
   }
 </style>

--- a/src/routes/app/[userId]/+page.svelte
+++ b/src/routes/app/[userId]/+page.svelte
@@ -144,8 +144,8 @@
       {#if address && !$dismissablesStore.includes('profile-drips-v1')}
         <div class="drips-v1-banner" out:fly|local={{ duration: 300, y: 16 }}>
           <Banner
-            title="Looking for Drips V1?"
-            description="The new Drips is now in public beta. You can still access Drips V1 at app.v1.drips.network."
+            title="Looking for the old Drips?"
+            description="The new Drips is now in public beta. You can still access the old Drips at app.v1.drips.network."
             button={{
               label: 'View profile on Drips V1',
               href: getDripsV1Url(address, $ens[address]?.name),

--- a/src/routes/app/[userId]/+page.svelte
+++ b/src/routes/app/[userId]/+page.svelte
@@ -15,10 +15,9 @@
   import { fade, fly } from 'svelte/transition';
   import decodeUserId from '$lib/utils/decode-user-id';
   import dismissablesStore from '$lib/stores/dismissables/dismissables.store';
-  import CrossSmall from 'radicle-design-system/icons/CrossSmall.svelte';
   import DripsV1Logo from '$lib/components/illustrations/drips-v1-logo.svelte';
-  import Button from '$lib/components/button/button.svelte';
   import TransitionedHeight from '$lib/components/transitioned-height/transitioned-height.svelte';
+  import Banner from '$lib/components/banner/banner.svelte';
 
   $: userId = $page.params.userId;
 
@@ -116,6 +115,22 @@
     description="We weren't able to find that profile."
   />
 {:else}
+  <TransitionedHeight>
+    {#if address && !$dismissablesStore.includes('profile-drips-v1')}
+      <div class="drips-v1-banner" out:fly|local={{ duration: 300, y: 16 }}>
+        <Banner
+          title="Looking for Drips V1?"
+          description="The new Drips is now in public beta. You can still access Drips V1 at app.v1.drips.network."
+          button={{
+            label: 'View profile on Drips V1',
+            href: getDripsV1Url(address, $ens[address]?.name),
+          }}
+          icon={DripsV1Logo}
+          on:dismiss={() => dismissablesStore.dismiss('profile-drips-v1')}
+        />
+      </div>
+    {/if}
+  </TransitionedHeight>
   <div class="profile">
     <SectionSkeleton placeholderOutline={false} loaded={Boolean(address)}>
       {#if address}
@@ -141,46 +156,10 @@
     <Balances userId={dripsUserId} />
     <Streams userId={dripsUserId} />
     <Splits userId={dripsUserId} />
-    <TransitionedHeight>
-      {#if address && !$dismissablesStore.includes('profile-drips-v1')}
-        <div out:fly|local={{ duration: 300, y: 16 }} class="drips-v1-card">
-          <button
-            class="close-button"
-            on:click={() => dismissablesStore.dismiss('profile-drips-v1')}
-          >
-            <CrossSmall />
-          </button>
-          <div class="top">
-            <div class="logo">
-              <DripsV1Logo />
-            </div>
-          </div>
-          <div class="bottom">
-            <h3 class="pixelated">Looking for Drips V1?</h3>
-            <p class="typo-text-small">
-              The new Drips is now in public beta. You can still access Drips V1 at
-              app.v1.drips.network.
-            </p>
-            <div class="action">
-              <a href={getDripsV1Url(address, $ens[address]?.name)} target="_blank" rel="noreferrer"
-                ><Button variant="normal">View profile on Drips V1</Button></a
-              >
-            </div>
-          </div>
-        </div>
-      {/if}
-    </TransitionedHeight>
   </div>
 {/if}
 
 <style>
-  .top {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    gap: 2rem;
-  }
-
   .identity {
     display: flex;
     gap: 1.5rem;
@@ -193,47 +172,8 @@
     gap: 2rem;
   }
 
-  .drips-v1-card {
-    border: 1px solid var(--color-foreground);
-    border-radius: 1.5rem 0 1.5rem 1.5rem;
-    width: 100%;
-    max-width: 24rem;
-    position: relative;
-    overflow: hidden;
-  }
-
-  .drips-v1-card > .close-button {
-    position: absolute;
-    top: 0.25rem;
-    right: 0.25rem;
-  }
-
-  .drips-v1-card > .top {
-    background-color: var(--color-primary-level-1);
-    padding: 0.75rem 0.75rem 0 0.75rem;
-    max-height: 3rem;
-  }
-
-  .drips-v1-card > .top > .logo {
-    background-color: var(--color-background);
-    padding: 0.75rem;
-    border-radius: 100rem;
-    width: 4rem;
-    height: 4rem;
-    transform: translateY(1rem);
-    border: 1px solid var(--color-primary-level-1);
-  }
-
-  .drips-v1-card > .bottom {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-    padding: 3rem 0.75rem 0.75rem 0.75rem;
-  }
-
-  .drips-v1-card > .bottom > .action {
-    display: flex;
-    margin-top: 0.25rem;
+  .drips-v1-banner {
+    padding-bottom: 3rem;
   }
 
   .profile {
@@ -262,12 +202,5 @@
     -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;
     overflow: hidden;
-  }
-
-  @media (max-width: 1056px) {
-    .top {
-      flex-direction: column;
-      align-items: flex-start;
-    }
   }
 </style>

--- a/src/routes/app/[userId]/+page.svelte
+++ b/src/routes/app/[userId]/+page.svelte
@@ -145,7 +145,7 @@
         <div class="drips-v1-banner" out:fly|local={{ duration: 300, y: 16 }}>
           <Banner
             title="Looking for the old Drips?"
-            description="The new Drips is now in public beta. You can still access the old Drips at app.v1.drips.network."
+            description="You can still access the previous Drips app at app.v1.drips.network."
             button={{
               label: 'View profile on Drips V1',
               href: getDripsV1Url(address, $ens[address]?.name),

--- a/src/routes/app/[userId]/+page.svelte
+++ b/src/routes/app/[userId]/+page.svelte
@@ -115,22 +115,6 @@
     description="We weren't able to find that profile."
   />
 {:else}
-  <TransitionedHeight>
-    {#if address && !$dismissablesStore.includes('profile-drips-v1')}
-      <div class="drips-v1-banner" out:fly|local={{ duration: 300, y: 16 }}>
-        <Banner
-          title="Looking for Drips V1?"
-          description="The new Drips is now in public beta. You can still access Drips V1 at app.v1.drips.network."
-          button={{
-            label: 'View profile on Drips V1',
-            href: getDripsV1Url(address, $ens[address]?.name),
-          }}
-          icon={DripsV1Logo}
-          on:dismiss={() => dismissablesStore.dismiss('profile-drips-v1')}
-        />
-      </div>
-    {/if}
-  </TransitionedHeight>
   <div class="profile">
     <SectionSkeleton placeholderOutline={false} loaded={Boolean(address)}>
       {#if address}
@@ -156,6 +140,22 @@
     <Balances userId={dripsUserId} />
     <Streams userId={dripsUserId} />
     <Splits userId={dripsUserId} />
+    <TransitionedHeight>
+      {#if address && !$dismissablesStore.includes('profile-drips-v1')}
+        <div class="drips-v1-banner" out:fly|local={{ duration: 300, y: 16 }}>
+          <Banner
+            title="Looking for Drips V1?"
+            description="The new Drips is now in public beta. You can still access Drips V1 at app.v1.drips.network."
+            button={{
+              label: 'View profile on Drips V1',
+              href: getDripsV1Url(address, $ens[address]?.name),
+            }}
+            icon={DripsV1Logo}
+            on:dismiss={() => dismissablesStore.dismiss('profile-drips-v1')}
+          />
+        </div>
+      {/if}
+    </TransitionedHeight>
   </div>
 {/if}
 


### PR DESCRIPTION
Adds a dismissable "looking for drips v1?" card at the bottom of profiles that allows quickly opening the current profile on Drips V1.

<img width="1633" alt="Screenshot 2023-03-13 at 10 35 11" src="https://user-images.githubusercontent.com/1018218/224662548-493fded6-2e88-4c6a-9023-1aa08f4618b5.png">
