### PR TITLE
fix: #408

### DIFF
--- a/src/lib/components/token/token.svelte
+++ b/src/lib/components/token/token.svelte
@@ -60,7 +60,7 @@
 </script>
 
 <div class="token size-{size}">
-  <div class="logo" style={`height: ${sizes[size]}px; width: ${sizes[size]}px`}>
+  <div class="logo" style="height: {sizes[size]}px; width: {sizes[size]}px">
     <CoinAnimation enable={shouldAnimate} {animateOnMount}>
       {#if tokenInfo?.logoURI && !imageFailed}
         <div class="background" class:loaded />
@@ -139,6 +139,7 @@
     display: flex;
     justify-content: center;
     align-items: center;
+    box-shadow: var(--elevation-low);
   }
 
   .background {
@@ -160,6 +161,9 @@
     width: 100%;
     opacity: 0;
     transition: opacity 0.3s;
+    border: 1px solid var(--color-foreground-level-6);
+    background-color: white;
+    padding: 8%;
   }
 
   img.loaded {


### PR DESCRIPTION
Adds outline, padding, and white background to all token logos.

The reason I think we need a white background is because many token logos are dark icons with transparent background.
The reason I think we need padding is because many token logos are not made to fit into a circle and have content going all the way to the edges.
The reason I think we need an outline is because many token logos have transparent (now white) backgrounds.

WDYT?

<img width="592" alt="Screenshot 2023-04-18 at 11 36 44" src="https://user-images.githubusercontent.com/1018218/232736716-e2d27b36-a5dd-49b6-a28c-2eb66232cf4b.png">
